### PR TITLE
Reduce allowed push notif data.

### DIFF
--- a/functions/android.js
+++ b/functions/android.js
@@ -7,10 +7,10 @@ module.exports = {
     let updateRateLimits = true;
 
     if(req.body.data){
-      for (const key of ['android', 'data']) {
-        if(req.body.data[key]){
-          payload[key] = req.body.data[key]
-        }
+
+      // URL to an image
+      if(req.body.data.image){
+        payload.data.image = req.body.data.image
       }
 
       // Handle the web actions by changing them into a format the app can handle
@@ -22,6 +22,17 @@ module.exports = {
           payload.data["action_"+(i+1)+"_title"] = action.title
         }
       }
+
+      // Allow setting of ttl
+      // https://firebase.google.com/docs/reference/admin/node/admin.messaging.AndroidConfig.html#optional-ttl
+      if(req.body.data.ttl){
+        payload.android.ttl = req.body.data.ttl
+      }
+      
+      // https://firebase.google.com/docs/reference/admin/node/admin.messaging.AndroidConfig.html#optional-priority
+      if(req.body.data.priority){
+        payload.android.priority = req.body.data.priority
+      }
     }
 
     // Always put message, title, and image in data so that the application can handle creating
@@ -31,10 +42,6 @@ module.exports = {
     }
     if(req.body.title) {
       payload.data.title = req.body.title
-    }
-    if(payload.android.image) {
-      payload.data.image = payload.android.image
-      delete payload.android.image
     }
 
     return { updateRateLimits: updateRateLimits, payload: payload };


### PR DESCRIPTION
We are getting reported issues because of 'breaking' changes to contract with push notifications.  This PR makes sure to only allow known fields to be sent to the application and ensures that we always process the messages rather than being auto handled by the system.
Allowed known fields for now:
```
title: 'title'
message: 'message' # REQUIRED
data:
  actions: # Up to 3 actions
    - title: 'Click Me'
      action: 'clicked'
  image: 'url' # Must be publicly facing for now
  ttl: 0
  priority: high
```