### PR TITLE
Exclude command pushes from limits

### DIFF
--- a/functions/android.js
+++ b/functions/android.js
@@ -57,6 +57,9 @@ module.exports = {
     // the notifications.  This allows us to safely create actionable/imaged notifications.
     if(req.body.message) {
       payload.data.message = req.body.message
+      if(req.body.message in ['request_location_update', 'clear_notification']) {
+        updateRateLimits = false
+      }
     }
     if(req.body.title) {
       payload.data.title = req.body.title


### PR DESCRIPTION
`request_location_update` and `clear_notification` won't count against limits.
Fixes: https://github.com/home-assistant/mobile-apps-fcm-push/issues/9