### PR TITLE
Strip file extension from `sound` for macOS 10.15 (Catalina)

### DIFF
--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 module.exports = {
   createPayload: function createPayload(req) {
     let payload = {
@@ -75,6 +77,11 @@ module.exports = {
             payload.apns.payload.aps.sound = req.body.data.sound;
           } else if(req.body.data.push && req.body.data.push.sound) {
             payload.apns.payload.aps.sound = req.body.data.push.sound;
+          }
+
+          if((typeof req.body.registration_info.os_version === "string")
+            && (req.body.registration_info.os_version.startsWith('10.15'))) {
+            payload.apns.payload.aps.sound = path.parse(payload.apns.payload.aps.sound).name
           }
 
           if (req.body.data.entity_id) {


### PR DESCRIPTION
macOS 10.15 requires the file extension not exist in the sound key, which is a change in behavior from how iOS keys work. To make sure notify groups continue to work, and ultimately for consistency, we need to strip the extension. This behavior was fixed in Big Sur beta 9, so we can expect macOS 11.0+ will continue to work as we expect.

Stripping the extension from the default-included sounds also works successfully.

Fixes home-assistant/iOS#1010. Strings updated externally on Lokalise.

# No OS Defined

```http
POST /home-assistant-mobile-apps/us-central1/sendPushNotification HTTP/1.1
…

{
    "message": "Message Text",
    "registration_info": {
        "app_id": "io.robbie.HomeAssistant"
    },
    "data": {
        "push": {
            "sound": "US-EN-Alexa-Back-Door-Opened.wav"
        }
    },
    "push_token": "…"
}
```

```json
{
	…
          "sound": "US-EN-Alexa-Back-Door-Opened.wav",
	…
}
```

# OS Defined (10.15) [strips]

```http
POST /home-assistant-mobile-apps/us-central1/sendPushNotification HTTP/1.1
…

{
    "message": "Message Text",
    "registration_info": {
        "app_id": "io.robbie.HomeAssistant",
        "os_version": "10.15"
    },
    "data": {
        "push": {
            "sound": "US-EN-Alexa-Back-Door-Opened.wav"
        }
    },
    "push_token": "…"
}
```

```json
{
	…
          "sound": "US-EN-Alexa-Back-Door-Opened",
	…
}
```

# OS Defined (10.15.5) [strips]

```http
POST /home-assistant-mobile-apps/us-central1/sendPushNotification HTTP/1.1
…

{
    "message": "Message Text",
    "registration_info": {
        "app_id": "io.robbie.HomeAssistant",
        "os_version": "10.15.5"
    },
    "data": {
        "push": {
            "sound": "US-EN-Alexa-Back-Door-Opened.wav"
        }
    },
    "push_token": "…"
}
```

```json
{
	…
          "sound": "US-EN-Alexa-Back-Door-Opened",
	…
}
```

# OS Defined (11.0)

```http
POST /home-assistant-mobile-apps/us-central1/sendPushNotification HTTP/1.1
…

{
    "message": "Message Text",
    "registration_info": {
        "app_id": "io.robbie.HomeAssistant",
        "os_version": "11.0"
    },
    "data": {
        "push": {
            "sound": "US-EN-Alexa-Back-Door-Opened.wav"
        }
    },
    "push_token": "…"
}
```

```json
{
	…
          "sound": "US-EN-Alexa-Back-Door-Opened.wav",
    …
}
```

# OS Defined (10.3.4 [Last iOS 10])

```http
POST /home-assistant-mobile-apps/us-central1/sendPushNotification HTTP/1.1
…

{
    "message": "Message Text",
    "registration_info": {
        "app_id": "io.robbie.HomeAssistant",
        "os_version": "10.3.4"
    },
    "data": {
        "push": {
            "sound": "US-EN-Alexa-Back-Door-Opened.wav"
        }
    },
    "push_token": "…"
}
```

```json
{
	…
          "sound": "US-EN-Alexa-Back-Door-Opened.wav",
    …
}
```

# OS Defined (13.7)

```http
POST /home-assistant-mobile-apps/us-central1/sendPushNotification HTTP/1.1
…

{
    "message": "Message Text",
    "registration_info": {
        "app_id": "io.robbie.HomeAssistant",
        "os_version": "13.7"
    },
    "data": {
        "push": {
            "sound": "US-EN-Alexa-Back-Door-Opened.wav"
        }
    },
    "push_token": "…"
}
```

```json
{
	…
          "sound": "US-EN-Alexa-Back-Door-Opened.wav",
    …
}
```