### PR TITLE
Allow deploying to other locations than us-central1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 This is the code that powers the official mobile app push notifications. Feel free to submit PRs!
 
-
 ## Developer Setup
 
 Install NPM dependencies:
+
 ```
 cd functions
 npm install
 ```
 
 Startup function for local testing:
+
 ```
 # Only Once
 npm install -g firebase-tools
@@ -21,4 +22,26 @@ firebase functions:config:get > .runtimeconfig.json
 
 # Whenever you want to start
 npm run serve
+```
+
+# Deploy your own
+
+Change the target project if needed:
+
+```
+# Only once
+sed -i s/home-assistant-mobile-apps/myproject/g ../.firebaserc
+```
+
+You can set the `app.region` setting if you want to deploy your functions in a another location than `us-central1`, e.g. `europe-west1`:
+
+```
+# Only once
+firebase functions:config:set app.region="us-central1"
+```
+
+Then deploy the Cloud Functions:
+
+```
+firebase deploy
 ```

--- a/functions/index.js
+++ b/functions/index.js
@@ -17,10 +17,6 @@ const logging = new Logging();
 const debug = isDebug()
 const MAX_NOTIFICATIONS_PER_DAY = 300;
 
-// process.env.FIREBASE_CONFIG.locationId only has the project's multi-region location, e.g. us-central or europe-west.
-// We need the complete Google Cloud Function location, e.g. us-central1 or europe-west1.
-// See https://firebase.google.com/docs/projects/locations#location-mr
-// and https://firebase.google.com/docs/functions/locations#selecting-regions_firestore-storage
 const region = functions.config().app && functions.config().app.region || "us-central1"
 const regionalFunctions = functions.region(region)
 
@@ -227,6 +223,9 @@ function reportError(err, step, req, notificationObj) {
       type: 'cloud_function',
       labels: {
         function_name: process.env.FUNCTION_TARGET,
+        // Use region from Cloud Function config as process.env.FIREBASE_CONFIG.locationId only has the project's multi-region location, e.g. us-central or europe-west, and we need a complete Google Cloud location, e.g. us-central1 or europe-west1, to invoke Google Cloud Logging API.
+        // See https://firebase.google.com/docs/projects/locations#location-mr
+        // and https://firebase.google.com/docs/functions/locations#selecting-regions_firestore-storage
         region: region
       }
     },


### PR DESCRIPTION
This PR allows to deploy the Cloud Functions in other locations than the default `us-central1` location.

The desired location can be configured with:

```
# firebase functions:config:set app.region="europe-west1"
```