### PR TITLE
Added new keys to support Chronometer notifications on Android

### DIFF
--- a/functions/android.js
+++ b/functions/android.js
@@ -46,7 +46,8 @@ module.exports = {
         'ticker', 'sticky', 'eventTime', 'localOnly', 'notificationPriority',
         'defaultSound', 'defaultVibrateTimings', 'defaultLightSettings', 'vibrateTimings',
         'visibility', 'notificationCount', 'lightSettings', 'image', 'timeout', 'importance', 
-		'subject', 'group', 'icon_url', 'ledColor', 'vibrationPattern', 'persistent'
+		'subject', 'group', 'icon_url', 'ledColor', 'vibrationPattern', 'persistent', 
+		'chronometer', 'when'
       ]) {
         if(req.body.data[key]){
           payload.data[key] = String(req.body.data[key])


### PR DESCRIPTION
New keys to support Chronometer notifications in PR https://github.com/home-assistant/android/pull/1154

* chronometer (enable Chronometer mode)
* when (timestamp for Chronometer in milliseconds)