### PR TITLE
Fix handling of dictionary-style sounds for macOS 10.15

### DIFF
--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -83,11 +83,11 @@ module.exports = {
             && (req.body.registration_info.os_version.startsWith('10.15'))) {
             switch(typeof payload.apns.payload.aps.sound) {
               case "string":
-                payload.apns.payload.aps.sound = path.parse(payload.apns.payload.aps.sound).name
+                payload.apns.payload.aps.sound = path.parse(payload.apns.payload.aps.sound).name;
                 break;
               case "object":
                 if(typeof payload.apns.payload.aps.sound.name === "string") {
-                  payload.apns.payload.aps.sound.name = path.parse(payload.apns.payload.aps.sound.name).name
+                  payload.apns.payload.aps.sound.name = path.parse(payload.apns.payload.aps.sound.name).name;
                 }
                 break;
             }

--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -81,7 +81,16 @@ module.exports = {
 
           if((typeof req.body.registration_info.os_version === "string")
             && (req.body.registration_info.os_version.startsWith('10.15'))) {
-            payload.apns.payload.aps.sound = path.parse(payload.apns.payload.aps.sound).name
+            switch(typeof payload.apns.payload.aps.sound) {
+              case "string":
+                payload.apns.payload.aps.sound = path.parse(payload.apns.payload.aps.sound).name
+                break;
+              case "object":
+                if(typeof payload.apns.payload.aps.sound.name === "string") {
+                  payload.apns.payload.aps.sound.name = path.parse(payload.apns.payload.aps.sound.name).name
+                }
+                break;
+            }
           }
 
           if (req.body.data.entity_id) {


### PR DESCRIPTION
This syntax doesn't make sense for non-critical alerts, but we should not fail badly at it.

Fixes home-assistant/iOS#1229.