### PR TITLE
feat: add a job to clean up older rate limit documents every day

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -68,6 +68,40 @@ exports.checkRateLimits = regionalFunctions.https.onRequest(async (req, res) => 
   });
 });
 
+exports.cleanupOldRateLimits = regionalFunctions.pubsub.schedule('every day 01:00').timeZone('Etc/UTC').onRun(async (context) => {
+  var today = getToday();
+  var ref = db.collection('rateLimits').where('__name__', '<', today);
+  try {
+    await deleteQueryBatch(db, ref);
+  } catch(err) {
+    console.error('Error when deleting older documents!', err);
+    throw err
+  }
+});
+
+async function deleteQueryBatch(db, query) {
+  const snapshot = await query.get();
+
+  const batchSize = snapshot.size;
+  if (batchSize === 0) {
+    // When there are no documents left, we are done
+    return;
+  }
+
+  // Delete documents in a batch
+  const batch = db.batch();
+  snapshot.docs.forEach((doc) => {
+    batch.delete(doc.ref);
+  });
+  await batch.commit();
+
+  // Recurse on the next process tick, to avoid
+  // exploding the stack.
+  process.nextTick(() => {
+    deleteQueryBatch(db, query);
+  });
+}
+
 async function handleRequest(req, res, payloadHandler) {
   if(debug) functions.logger.info('Handling request', { requestBody: JSON.stringify(req.body) });
   var today = getToday();


### PR DESCRIPTION
Will keep our costs down and make the web UI usable again.

There's no way to test this against production Firestore locally it seems, so just throwing this up and hoping it works. It's all Google example code, so it _should_. Will check in 24 hours to ensure.