### PR TITLE
Work around error when setting `notification` to `{}`

### DIFF
--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -49,13 +49,15 @@ module.exports = {
     if(req.body.registration_info.app_id.indexOf('io.robbie.HomeAssistant') > -1) {
       // Enable old SNS iOS specific push setup.
       if (req.body.message === 'request_location_update' || req.body.message === 'request_location_updates') {
-        payload.notification = {};
+        // 2021-04-13 setting `notification` to `{}`, `null` or not present causes `messaging/invalid-argument`
+        // payload.notification = {};
         payload.apns.payload.aps = {};
         payload.apns.payload.aps.contentAvailable = true;
         payload.apns.payload.homeassistant = { 'command': 'request_location_update' };
         updateRateLimits = false;
       } else if (req.body.message === 'clear_badge') {
-        payload.notification = {};
+        // 2021-04-13 setting `notification` to `{}`, `null` or not present causes `messaging/invalid-argument`
+        // payload.notification = {};
         payload.apns.payload.aps = {};
         payload.apns.payload.aps.contentAvailable = true;
         payload.apns.payload.aps.badge = 0;


### PR DESCRIPTION
A recent Firebase change appears to have made these notifications error if the `notification` key is provided with empty content. The `aps` customization we do appears to override any alerting the default behavior does, so this shouldn't cause these to become alerts.

In my testing, both `clear_badge` and `request_location_update` come through as silent notifications still.