### PR TITLE
Unify a few iOS/Android notification options

### DIFF
--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -63,6 +63,18 @@ module.exports = {
         payload.apns.payload.aps.badge = 0;
         payload.apns.payload.homeassistant = { 'command': 'clear_badge' };
         updateRateLimits = false;
+      } else if (req.body.message === 'clear_notification') {
+        payload.notification = {};
+        payload.apns.payload.aps = {};
+        payload.apns.payload.aps.contentAvailable = true;
+        payload.apns.payload.homeassistant = { 'command': 'clear_notification' };
+
+        if (req.body.data) {
+          payload.apns.payload.homeassistant.tag = req.body.data.tag;
+        }
+
+        payload.apns.payload.homeassistant.collapseId = payload.apns.headers['apns-collapse-id'];
+        updateRateLimits = false;
       } else {
         if(req.body.data) {
           if (req.body.data.subtitle) {

--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -118,6 +118,10 @@ module.exports = {
           if (req.body.data.presentation_options) {
             payload.apns.payload.presentation_options = req.body.data.presentation_options;
           }
+
+          if (typeof req.body.data.tag === "string") {
+            payload.apns.headers['apns-collapse-id'] = req.body.data.tag;
+          }
         }
 
         payload.apns.payload.aps.mutableContent = true;

--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -122,6 +122,10 @@ module.exports = {
           if (typeof req.body.data.tag === "string") {
             payload.apns.headers['apns-collapse-id'] = req.body.data.tag;
           }
+
+          if (typeof req.body.data.group === "string") {
+            payload.apns.payload.aps['thread-id'] = req.body.data.group;
+          }
         }
 
         payload.apns.payload.aps.mutableContent = true;


### PR DESCRIPTION
- Uses the `tag` key as an alias for collapse id
- Uses the `group` key as an alias for thread id
- Adds support for `clear_notification` to be sent to the app as a command