### PR TITLE
Use alert (not background) for clear_badge

### DIFF
--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -57,9 +57,7 @@ module.exports = {
       } else if (req.body.message === 'clear_badge') {
         payload.notification = {};
         payload.apns.payload.aps = {};
-        payload.apns.payload.aps.contentAvailable = true;
         payload.apns.payload.aps.badge = 0;
-        payload.apns.payload.homeassistant = { 'command': 'clear_badge' };
         updateRateLimits = false;
       } else if (req.body.message === 'clear_notification') {
         payload.notification = {};

--- a/functions/test/fixtures/legacy/command_clear_badge.json
+++ b/functions/test/fixtures/legacy/command_clear_badge.json
@@ -10,15 +10,11 @@
     },
     "rate_limit": false,
     "headers": {
-        "apns-push-type": "background"
+        "apns-push-type": "alert"
     },
     "payload": {
         "aps": {
-            "contentAvailable": true,
             "badge": 0
-        },
-        "homeassistant": {
-            "command": "clear_badge"
         }
     }
 }


### PR DESCRIPTION
We don't need to wake the app or have it do work, since setting the badge to 0 is something we can do directly in the notification. Using background here makes it potentially take a while to execute.