### PR TITLE
Add 'test_push_source' debug message

### DIFF
--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -206,6 +206,11 @@ module.exports = {
           delete payload.apns.payload.aps.alert.body;
           delete payload.apns.payload.aps.sound;
         }
+
+        if (req.body.message === 'test_push_source') {
+          payload.apns.payload.aps.alert.title = req.body.message;
+          payload.apns.payload.aps.alert.body = 'apns-fcm';
+        }
       }
     }
 

--- a/functions/test/fixtures/legacy/command_test_push_source.json
+++ b/functions/test/fixtures/legacy/command_test_push_source.json
@@ -1,0 +1,23 @@
+{
+    "input": {
+        "message": "test_push_source",
+        "registration_info": {
+            "app_id": "io.robbie.HomeAssistant.dev",
+            "os_version": "10.15",
+            "app_version": "2021.5"
+        }
+    },
+    "rate_limit": true,
+    "headers": {
+        "apns-push-type": "alert"
+    },
+    "payload": {
+        "aps": {
+            "alert": {
+                "title": "test_push_source",
+                "body": "apns-fcm"
+            },
+            "sound": "default"
+        }
+    }
+}


### PR DESCRIPTION
This allows for us to vary the message based on what's sending it, so we can test if a notification came through local push or APNS.