### PR TITLE
Set execution timeout to 10s

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -18,7 +18,7 @@ const debug = isDebug();
 const MAX_NOTIFICATIONS_PER_DAY = 500;
 
 const region = functions.config().app && functions.config().app.region || "us-central1";
-const regionalFunctions = functions.region(region);
+const regionalFunctions = functions.region(region).runWith({ timeoutSeconds: 10 });
 
 exports.androidV1 = regionalFunctions.https.onRequest(async (req, res) => {
   return handleRequest(req, res, android.createPayload);


### PR DESCRIPTION
Limit execution time by setting a lower than default timeout setting.

https://firebase.google.com/docs/functions/manage-functions#set_timeout_and_memory_allocation
https://firebase.google.com/docs/reference/functions/function_configuration.runtimeoptions#optional-timeoutseconds

I'm not really sure how to test/verify this, but according to their documentation, this seems like the proper implementation of this setting.