### PR TITLE
Add visibility to Android notification keys

### DIFF
--- a/functions/android.js
+++ b/functions/android.js
@@ -49,7 +49,7 @@ module.exports = {
         'subject', 'group', 'icon_url', 'ledColor', 'vibrationPattern', 'persistent', 
         'chronometer', 'when', 'alert_once', 'intent_class_name', 'notification_icon',
         'ble_advertise', 'ble_transmit', 'video', 'high_accuracy_update_interval',
-        'package_name'
+        'package_name', 'visibility'
       ]) {
         if (req.body.data[key]){
           payload.data[key] = String(req.body.data[key]);


### PR DESCRIPTION
This PR + home-assistant/android#2505 adds support for setting the visibility of push notifications for Android devices, which allows you to control what notification content is visible on the lock screen when the device is locked.

Please see the linked Android PR for more details.