### PR TITLE
Mark 'clear_notification' message as background notification on iOS

### DIFF
--- a/functions/ios.js
+++ b/functions/ios.js
@@ -55,6 +55,12 @@ module.exports = {
         payload.apns.payload.aps.badge = 0;
         payload.apns.payload.homeassistant = { 'command': 'clear_badge' };
         updateRateLimits = false;
+      } else if (req.body.message === 'clear_notification') {
+        payload.notification = {};
+        payload.apns.payload.aps = {};
+        payload.apns.payload.aps.contentAvailable = true;
+        payload.apns.payload.homeassistant = { 'command': 'clear_notification' };
+        updateRateLimits = false;
       } else {
         if (req.body.data) {
           if (req.body.data.subtitle) {


### PR DESCRIPTION
I don't know if it is possible for me to test this.

Currently clear_notification only works when using local push notifications or if the app is active.

Relevant part of the iOS app: https://github.com/home-assistant/iOS/blob/master/Sources/Shared/Notifications/NotificationCommands/NotificationsCommandManager.swift#L21

Scripts for testing:

```yaml
alias: Notification send test
sequence:
  - service: notify.mobile_app_ipad
    data:
      message: foobar
      data:
        tag: notification_testing
mode: single
```

```yaml
alias: Notification clear test
sequence:
  - service: notify.mobile_app_ipad
    data:
      message: clear_notification
      data:
        tag: notification_testing
mode: single
```