### PR TITLE
Pass badge number with clear_notification command

### DIFF
--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -77,8 +77,8 @@ module.exports = {
           payload.apns.payload.homeassistant.tag = req.body.data.tag;
         }
 
-        if (req.body.data.badge) {
-          payload.apns.payload.aps.badge = req.body.data.badge;
+        if (req.body.data.push.badge) {
+          payload.apns.payload.aps.badge = req.body.data.push.badge;
         }
 
         if (payload.apns.headers['apns-collapse-id']) {

--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -77,6 +77,10 @@ module.exports = {
           payload.apns.payload.homeassistant.tag = req.body.data.tag;
         }
 
+        if (req.body.data.badge) {
+          payload.apns.payload.aps.badge = req.body.data.badge;
+        }
+
         if (payload.apns.headers['apns-collapse-id']) {
           payload.apns.payload.homeassistant.collapseId = payload.apns.headers['apns-collapse-id'];
         }


### PR DESCRIPTION
Updating badge number along with clearing a notification (usually) works with local push, so I think it should also work with remote push.

fixes https://github.com/home-assistant/iOS/issues/2462