### PR TITLE
Fix GitHub Actions deploy on push to main (branch name changed)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: Deploy
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   functions:


### PR DESCRIPTION
The deploy action no longer seems to run because someone renamed the working branch from `master` to `main` about 7 months ago but didn't update the actions to match, so nothing has happened since even though there have been commits. This PR fixes it by updating the branch names in actions.

![screenshot showing last action run for deploy was 7 months ago](https://github.com/home-assistant/mobile-apps-fcm-push/assets/8148535/713d5a21-95d3-4503-add8-8a99e7f85d57)

Fixes home-assistant/android#4443