### PR TITLE
Include notification data if set, not if truthy, for Android

### DIFF
--- a/functions/android.js
+++ b/functions/android.js
@@ -58,7 +58,7 @@ module.exports = {
         'app_lock_enabled', 'app_lock_timeout', 'home_bypass_enabled', 'car_ui', 'ble_measured_power',
         'progress', 'progress_max', 'progress_indeterminate'
       ]) {
-        if (req.body.data[key]){
+        if (key in req.body.data){
           payload.data[key] = String(req.body.data[key]);
         }
       }


### PR DESCRIPTION
Fix home-assistant/android#5033 by including the notification's extra `data` for a key if it is set, instead of checking that the key (exists and) has a truthy value.

Checking for truthy values doesn't appear to have been a deliberate choice based on git history, and this better matches the behavior of getting notifications directly from the websocket connection.

(iOS code doesn't do any allowlisting and simply passes along the entire `data` object if it exists, so no adjustments needed there.)