### PR TITLE
Use proper debug comparison.

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -163,7 +163,7 @@ async function handleRequest(req, res, payloadHandler) {
 function isDebug() {
   let conf = functions.config();
   if (conf.debug){
-    return conf.debug.local;
+    return conf.debug.local === 'true';
   }
   return false;
 }


### PR DESCRIPTION
The config variables are strings, so if config.debug.local was set to "false", the test would still bool evaluate as true. This comparison now returns a bool value.