### PR TITLE
Add redis rate limiter

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -11,7 +11,7 @@ initializeApp();
 const android = require('./android');
 const ios = require('./ios');
 const legacy = require('./legacy');
-const RateLimiter = require('./rate-limiter');
+const { FirestoreRateLimiter, RedisRateLimiter } = require('./rate-limiter');
 
 const messaging = getMessaging();
 
@@ -20,7 +20,18 @@ const logging = new Logging();
 const debug = isDebug();
 const MAX_NOTIFICATIONS_PER_DAY = parseInt(process.env.MAX_NOTIFICATIONS_PER_DAY || '500');
 
-const rateLimiter = new RateLimiter(MAX_NOTIFICATIONS_PER_DAY, debug);
+// Use Redis rate limiter if Redis config is available, otherwise use Firestore
+let rateLimiter;
+if (process.env.REDIS_HOST && process.env.REDIS_PORT) {
+  rateLimiter = new RedisRateLimiter(
+    MAX_NOTIFICATIONS_PER_DAY,
+    debug,
+    process.env.REDIS_HOST,
+    parseInt(process.env.REDIS_PORT, 10),
+  );
+} else {
+  rateLimiter = new FirestoreRateLimiter(MAX_NOTIFICATIONS_PER_DAY, debug);
+}
 
 const region = (functions.config().app && functions.config().app.region) || 'us-central1';
 const regionalFunctions = functions.region(region).runWith({ timeoutSeconds: 10 });

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,7 +8,8 @@
       "dependencies": {
         "@google-cloud/logging": "^11.0.0",
         "firebase-admin": "^12.1.0",
-        "firebase-functions": "^5.0.1"
+        "firebase-functions": "^5.0.1",
+        "ioredis": "^5.6.1"
       },
       "devDependencies": {
         "eslint": "^8.16.0",
@@ -1020,6 +1021,12 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2504,6 +2511,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2727,6 +2743,15 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -3983,6 +4008,30 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "node_modules/ioredis": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.1.tgz",
+      "integrity": "sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5036,10 +5085,22 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -5906,6 +5967,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6344,6 +6426,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "@google-cloud/logging": "^11.0.0",
     "firebase-admin": "^12.1.0",
-    "firebase-functions": "^5.0.1"
+    "firebase-functions": "^5.0.1",
+    "ioredis": "^5.6.1"
   },
   "devDependencies": {
     "eslint": "^8.16.0",

--- a/functions/rate-limiter/firestore-rate-limiter.js
+++ b/functions/rate-limiter/firestore-rate-limiter.js
@@ -34,10 +34,10 @@ const db = getFirestore();
  */
 
 /**
- * Manages rate limiting for push notifications without caching documents.
+ * Manages rate limiting for push notifications using Firestore as the backend.
  * All operations require the token to be passed and directly query/update Firestore.
  */
-class RateLimiter {
+class FirestoreRateLimiter {
   /**
    * Creates a new RateLimiter instance.
    *
@@ -273,4 +273,4 @@ function getFirestoreTimestamp() {
   return Timestamp.fromDate(endDate);
 }
 
-module.exports = RateLimiter;
+module.exports = FirestoreRateLimiter;

--- a/functions/rate-limiter/firestore-rate-limiter.js
+++ b/functions/rate-limiter/firestore-rate-limiter.js
@@ -2,30 +2,17 @@
 
 const { getFirestore, Timestamp } = require('firebase-admin/firestore');
 
-const TWENTY_FOUR_HOURS_IN_MS = 86400000;
+const { getToday, TWENTY_FOUR_HOURS_IN_MS } = require('./util');
 
 const db = getFirestore();
 
 /**
- * @typedef {Object} RateLimits
- * @property {number} attempts - Total number of attempts made
- * @property {number} successful - Number of successfully delivered notifications
- * @property {number} errors - Number of failed notification attempts
- * @property {number} total - Total number of notifications (successful + errors)
- * @property {number} maximum - Maximum notifications allowed per day
- * @property {number} remaining - Remaining notifications allowed today
- * @property {Date} resetsAt - When the rate limit resets
+ * @typedef {import('./util').RateLimits} RateLimits
+ * @typedef {import('./util').RateLimitStatus} RateLimitStatus
  */
 
 /**
- * @typedef {Object} RateLimitStatus
- * @property {boolean} isRateLimited - Whether the token has exceeded the rate limit
- * @property {boolean} shouldSendRateLimitNotification - Whether to send a rate limit notification
- * @property {RateLimits} rateLimits - Current rate limit statistics
- */
-
-/**
- * @typedef {Object} RateLimitData
+ * @typedef {Object} FirestoreRateLimitData
  * @property {number} attemptsCount - Number of attempts
  * @property {number} deliveredCount - Number of delivered notifications
  * @property {number} errorCount - Number of errors
@@ -226,7 +213,7 @@ class FirestoreRateLimiter {
    * Converts internal rate limit data to a user-friendly format.
    *
    * @private
-   * @param {RateLimitData} doc - The internal rate limit data
+   * @param {FirestoreRateLimitData} doc - The internal rate limit data
    * @returns {RateLimits} User-friendly rate limit statistics
    */
   _getRateLimitsObject(doc) {
@@ -244,20 +231,6 @@ class FirestoreRateLimiter {
       resetsAt: new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1),
     };
   }
-}
-
-/**
- * Gets today's date in YYYYMMDD format for use as a Firestore document ID.
- *
- * @private
- * @returns {string} Today's date as YYYYMMDD
- */
-function getToday() {
-  const today = new Date();
-  const dd = String(today.getDate()).padStart(2, '0');
-  const mm = String(today.getMonth() + 1).padStart(2, '0');
-  const yyyy = today.getFullYear();
-  return yyyy + mm + dd;
 }
 
 /**

--- a/functions/rate-limiter/index.js
+++ b/functions/rate-limiter/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const FirestoreRateLimiter = require('./firestore-rate-limiter');
+const RedisRateLimiter = require('./redis-rate-limiter');
+
+module.exports = {
+  FirestoreRateLimiter,
+  RedisRateLimiter,
+};

--- a/functions/rate-limiter/redis-rate-limiter.js
+++ b/functions/rate-limiter/redis-rate-limiter.js
@@ -1,25 +1,12 @@
 'use strict';
 
+const { getToday, TWENTY_FOUR_HOURS_IN_MS } = require('./util');
+
 const Redis = require('ioredis');
 
-const TWENTY_FOUR_HOURS_IN_MS = 86400000;
-
 /**
- * @typedef {Object} RateLimits
- * @property {number} attempts - Total number of attempts made
- * @property {number} successful - Number of successfully delivered notifications
- * @property {number} errors - Number of failed notification attempts
- * @property {number} total - Total number of notifications (successful + errors)
- * @property {number} maximum - Maximum notifications allowed per day
- * @property {number} remaining - Remaining notifications allowed today
- * @property {Date} resetsAt - When the rate limit resets
- */
-
-/**
- * @typedef {Object} RateLimitStatus
- * @property {boolean} isRateLimited - Whether the token has exceeded the rate limit
- * @property {boolean} shouldSendRateLimitNotification - Whether to send a rate limit notification
- * @property {RateLimits} rateLimits - Current rate limit statistics
+ * @typedef {import('./util').RateLimits} RateLimits
+ * @typedef {import('./util').RateLimitStatus} RateLimitStatus
  */
 
 /**
@@ -238,20 +225,6 @@ class RedisRateLimiter {
   async close() {
     await this.redis.quit();
   }
-}
-
-/**
- * Gets today's date in YYYYMMDD format for use in Redis keys.
- *
- * @private
- * @returns {string} Today's date as YYYYMMDD
- */
-function getToday() {
-  const today = new Date();
-  const dd = String(today.getDate()).padStart(2, '0');
-  const mm = String(today.getMonth() + 1).padStart(2, '0');
-  const yyyy = today.getFullYear();
-  return yyyy + mm + dd;
 }
 
 module.exports = RedisRateLimiter;

--- a/functions/rate-limiter/redis-rate-limiter.js
+++ b/functions/rate-limiter/redis-rate-limiter.js
@@ -1,0 +1,257 @@
+'use strict';
+
+const Redis = require('ioredis');
+
+const TWENTY_FOUR_HOURS_IN_MS = 86400000;
+
+/**
+ * @typedef {Object} RateLimits
+ * @property {number} attempts - Total number of attempts made
+ * @property {number} successful - Number of successfully delivered notifications
+ * @property {number} errors - Number of failed notification attempts
+ * @property {number} total - Total number of notifications (successful + errors)
+ * @property {number} maximum - Maximum notifications allowed per day
+ * @property {number} remaining - Remaining notifications allowed today
+ * @property {Date} resetsAt - When the rate limit resets
+ */
+
+/**
+ * @typedef {Object} RateLimitStatus
+ * @property {boolean} isRateLimited - Whether the token has exceeded the rate limit
+ * @property {boolean} shouldSendRateLimitNotification - Whether to send a rate limit notification
+ * @property {RateLimits} rateLimits - Current rate limit statistics
+ */
+
+/**
+ * @typedef {Object} RateLimitData
+ * @property {number} attemptsCount - Number of attempts
+ * @property {number} deliveredCount - Number of delivered notifications
+ * @property {number} errorCount - Number of errors
+ * @property {number} totalCount - Total notifications sent
+ */
+
+/**
+ * Manages rate limiting for push notifications using Redis as the backend.
+ * Uses Redis hashes for atomic and efficient updates.
+ */
+class RedisRateLimiter {
+  /**
+   * Creates a new RedisRateLimiter instance.
+   *
+   * @param {number} [maxNotificationsPerDay] - Maximum notifications allowed per day
+   * @param {boolean} [debug=false] - Whether to enable debug logging
+   * @param {string} [redisHost] - Redis host
+   * @param {number} [redisPort] - Redis port
+   */
+  constructor(maxNotificationsPerDay, debug = false, redisHost = 'localhost', redisPort = 6379) {
+    this.redis = new Redis({
+      host: redisHost,
+      port: redisPort,
+      retryStrategy: (times) => {
+        const delay = Math.min(times * 50, 2000);
+        return delay;
+      },
+    });
+    this.maxNotificationsPerDay = maxNotificationsPerDay;
+    this.debug = debug;
+  }
+
+  /**
+   * Gets the Redis key for the rate limit data.
+   *
+   * @private
+   * @param {string} token - The push notification token
+   * @returns {string} The Redis key
+   */
+  _getRedisKey(token) {
+    const today = getToday();
+    return `rate_limit:${token}:${today}`;
+  }
+
+  /**
+   * Gets the TTL in seconds until end of day.
+   *
+   * @private
+   * @returns {number} TTL in seconds
+   */
+  _getTTLSeconds() {
+    const now = new Date().getTime();
+    const endOfDay = now - (now % TWENTY_FOUR_HOURS_IN_MS) + TWENTY_FOUR_HOURS_IN_MS;
+    const ttlMs = endOfDay - now;
+    return Math.ceil(ttlMs / 1000);
+  }
+
+  /**
+   * Checks the current rate limit status for the token without modifying any counters.
+   *
+   * @param {string} token - The push notification token
+   * @returns {Promise<RateLimitStatus>} The current rate limit status
+   * @throws {Error} If Redis operations fail
+   */
+  async checkRateLimit(token) {
+    const key = this._getRedisKey(token);
+    const data = await this.redis.hgetall(key);
+
+    const docData = {
+      attemptsCount: parseInt(data.attemptsCount || '0', 10),
+      deliveredCount: parseInt(data.deliveredCount || '0', 10),
+      errorCount: parseInt(data.errorCount || '0', 10),
+      totalCount: parseInt(data.totalCount || '0', 10),
+    };
+
+    const isRateLimited = docData.deliveredCount >= this.maxNotificationsPerDay;
+    const shouldSendRateLimitNotification = docData.deliveredCount === this.maxNotificationsPerDay;
+
+    return {
+      isRateLimited,
+      shouldSendRateLimitNotification,
+      rateLimits: this._getRateLimitsObject(docData),
+    };
+  }
+
+  /**
+   * Records a notification attempt and atomically increments the attempts counter.
+   *
+   * @param {string} token - The push notification token
+   * @returns {Promise<RateLimitStatus>} The updated rate limit status
+   * @throws {Error} If Redis operations fail
+   */
+  async recordAttempt(token) {
+    const key = this._getRedisKey(token);
+
+    // Use Redis transaction for atomic operations
+    const pipeline = this.redis.pipeline();
+    pipeline.hincrby(key, 'attemptsCount', 1);
+    pipeline.expire(key, this._getTTLSeconds());
+    pipeline.hgetall(key);
+
+    const results = await pipeline.exec();
+    const [, , [, data]] = results;
+
+    const docData = {
+      attemptsCount: parseInt(data.attemptsCount || '0', 10),
+      deliveredCount: parseInt(data.deliveredCount || '0', 10),
+      errorCount: parseInt(data.errorCount || '0', 10),
+      totalCount: parseInt(data.totalCount || '0', 10),
+    };
+
+    const isRateLimited = docData.deliveredCount >= this.maxNotificationsPerDay;
+    const shouldSendRateLimitNotification = docData.deliveredCount === this.maxNotificationsPerDay;
+
+    return {
+      isRateLimited,
+      shouldSendRateLimitNotification,
+      rateLimits: this._getRateLimitsObject(docData),
+    };
+  }
+
+  /**
+   * Records a successful notification delivery.
+   * Atomically increments both delivered and total counters.
+   * Note: Should be called after recordAttempt() to avoid double-counting attempts.
+   *
+   * @param {string} token - The push notification token
+   * @returns {Promise<RateLimits>} The updated rate limit statistics
+   * @throws {Error} If Redis operations fail
+   */
+  async recordSuccess(token) {
+    const key = this._getRedisKey(token);
+
+    // Use Redis transaction for atomic operations
+    const pipeline = this.redis.pipeline();
+    pipeline.hincrby(key, 'deliveredCount', 1);
+    pipeline.hincrby(key, 'totalCount', 1);
+    pipeline.expire(key, this._getTTLSeconds());
+    pipeline.hgetall(key);
+
+    const results = await pipeline.exec();
+    const [, , , [, data]] = results;
+
+    const docData = {
+      attemptsCount: parseInt(data.attemptsCount || '0', 10),
+      deliveredCount: parseInt(data.deliveredCount || '0', 10),
+      errorCount: parseInt(data.errorCount || '0', 10),
+      totalCount: parseInt(data.totalCount || '0', 10),
+    };
+
+    return this._getRateLimitsObject(docData);
+  }
+
+  /**
+   * Records a failed notification delivery.
+   * Atomically increments both error and total counters.
+   * Note: Should be called after recordAttempt() to avoid double-counting attempts.
+   *
+   * @param {string} token - The push notification token
+   * @returns {Promise<RateLimits>} The updated rate limit statistics
+   * @throws {Error} If Redis operations fail
+   */
+  async recordError(token) {
+    const key = this._getRedisKey(token);
+
+    // Use Redis transaction for atomic operations
+    const pipeline = this.redis.pipeline();
+    pipeline.hincrby(key, 'errorCount', 1);
+    pipeline.hincrby(key, 'totalCount', 1);
+    pipeline.expire(key, this._getTTLSeconds());
+    pipeline.hgetall(key);
+
+    const results = await pipeline.exec();
+    const [, , , [, data]] = results;
+
+    const docData = {
+      attemptsCount: parseInt(data.attemptsCount || '0', 10),
+      deliveredCount: parseInt(data.deliveredCount || '0', 10),
+      errorCount: parseInt(data.errorCount || '0', 10),
+      totalCount: parseInt(data.totalCount || '0', 10),
+    };
+
+    return this._getRateLimitsObject(docData);
+  }
+
+  /**
+   * Converts internal rate limit data to a user-friendly format.
+   *
+   * @private
+   * @param {RateLimitData} doc - The internal rate limit data
+   * @returns {RateLimits} User-friendly rate limit statistics
+   */
+  _getRateLimitsObject(doc) {
+    const d = new Date();
+    let remainingCount = this.maxNotificationsPerDay - doc.deliveredCount;
+    if (remainingCount < 0) remainingCount = 0;
+
+    return {
+      attempts: doc.attemptsCount || 0,
+      successful: doc.deliveredCount || 0,
+      errors: doc.errorCount || 0,
+      total: doc.totalCount || 0,
+      maximum: this.maxNotificationsPerDay,
+      remaining: remainingCount,
+      resetsAt: new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1),
+    };
+  }
+
+  /**
+   * Closes the Redis connection.
+   */
+  async close() {
+    await this.redis.quit();
+  }
+}
+
+/**
+ * Gets today's date in YYYYMMDD format for use in Redis keys.
+ *
+ * @private
+ * @returns {string} Today's date as YYYYMMDD
+ */
+function getToday() {
+  const today = new Date();
+  const dd = String(today.getDate()).padStart(2, '0');
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const yyyy = today.getFullYear();
+  return yyyy + mm + dd;
+}
+
+module.exports = RedisRateLimiter;

--- a/functions/rate-limiter/util.js
+++ b/functions/rate-limiter/util.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * @typedef {Object} RateLimits
+ * @property {number} attempts - Total number of attempts made
+ * @property {number} successful - Number of successfully delivered notifications
+ * @property {number} errors - Number of failed notification attempts
+ * @property {number} total - Total number of notifications (successful + errors)
+ * @property {number} maximum - Maximum notifications allowed per day
+ * @property {number} remaining - Remaining notifications allowed today
+ * @property {Date} resetsAt - When the rate limit resets
+ */
+
+/**
+ * @typedef {Object} RateLimitStatus
+ * @property {boolean} isRateLimited - Whether the token has exceeded the rate limit
+ * @property {boolean} shouldSendRateLimitNotification - Whether to send a rate limit notification
+ * @property {RateLimits} rateLimits - Current rate limit statistics
+ */
+
+const TWENTY_FOUR_HOURS_IN_MS = 86400000;
+
+/**
+ * Gets today's date in YYYYMMDD format for use in Redis keys.
+ *
+ * @private
+ * @returns {string} Today's date as YYYYMMDD
+ */
+function getToday() {
+  const today = new Date();
+  const dd = String(today.getDate()).padStart(2, '0');
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const yyyy = today.getFullYear();
+  return yyyy + mm + dd;
+}
+
+exports.getToday = getToday;
+exports.TWENTY_FOUR_HOURS_IN_MS = TWENTY_FOUR_HOURS_IN_MS;

--- a/functions/test/rate-limiter/firestore-rate-limiter.test.js
+++ b/functions/test/rate-limiter/firestore-rate-limiter.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { createMockRateLimitData, MockDataManager, getToday } = require('../utils/mock-factories');
+const { createMockRateLimitData, MockDataManager } = require('../utils/mock-factories');
+const { getToday } = require('../../rate-limiter/util');
 
 const { assertRateLimits } = require('../utils/assertion-helpers');
 

--- a/functions/test/rate-limiter/redis-rate-limiter.test.js
+++ b/functions/test/rate-limiter/redis-rate-limiter.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Redis = require('ioredis');
+const { getToday } = require('../../rate-limiter/util');
 
 jest.mock('ioredis');
 
@@ -52,13 +53,6 @@ describe('RedisRateLimiter', () => {
     jest.restoreAllMocks();
   });
 
-  function getToday() {
-    const today = new Date();
-    const dd = String(today.getDate()).padStart(2, '0');
-    const mm = String(today.getMonth() + 1).padStart(2, '0');
-    const yyyy = today.getFullYear();
-    return yyyy + mm + dd;
-  }
 
   describe('Basic functionality', () => {
     test('should initialize with zero counts', async () => {

--- a/functions/test/rate-limiter/redis-rate-limiter.test.js
+++ b/functions/test/rate-limiter/redis-rate-limiter.test.js
@@ -1,0 +1,632 @@
+'use strict';
+
+const Redis = require('ioredis');
+
+jest.mock('ioredis');
+
+const RedisRateLimiter = require('../../rate-limiter/redis-rate-limiter');
+
+describe('RedisRateLimiter', () => {
+  let mockRedis;
+  let rateLimiter;
+  let retryStrategyFn;
+  const testToken = 'test-token-123';
+  const maxNotificationsPerDay = 150;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Set up fake timers starting at a specific date
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T10:00:00Z'));
+
+    // Mock Redis instance
+    mockRedis = {
+      hgetall: jest.fn(),
+      pipeline: jest.fn(),
+      hincrby: jest.fn(),
+      expire: jest.fn(),
+      quit: jest.fn(),
+    };
+
+    // Mock pipeline execution
+    const mockPipeline = {
+      hincrby: jest.fn().mockReturnThis(),
+      expire: jest.fn().mockReturnThis(),
+      hgetall: jest.fn().mockReturnThis(),
+      exec: jest.fn(),
+    };
+
+    mockRedis.pipeline.mockReturnValue(mockPipeline);
+
+    // Capture the retry strategy function
+    Redis.mockImplementation((config) => {
+      retryStrategyFn = config.retryStrategy;
+      return mockRedis;
+    });
+
+    rateLimiter = new RedisRateLimiter(maxNotificationsPerDay);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function getToday() {
+    const today = new Date();
+    const dd = String(today.getDate()).padStart(2, '0');
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    const yyyy = today.getFullYear();
+    return yyyy + mm + dd;
+  }
+
+  describe('Basic functionality', () => {
+    test('should initialize with zero counts', async () => {
+      mockRedis.hgetall.mockResolvedValue({});
+
+      const status = await rateLimiter.checkRateLimit(testToken);
+
+      expect(status.isRateLimited).toBe(false);
+      expect(status.shouldSendRateLimitNotification).toBe(false);
+      expect(status.rateLimits).toEqual({
+        attempts: 0,
+        successful: 0,
+        errors: 0,
+        total: 0,
+        maximum: maxNotificationsPerDay,
+        remaining: maxNotificationsPerDay,
+        resetsAt: new Date('2024-01-02T00:00:00.000Z'),
+      });
+    });
+
+    test('should increment attempts counter', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 1],
+        [null, 'OK'],
+        [null, { attemptsCount: '1', deliveredCount: '0', errorCount: '0', totalCount: '0' }],
+      ]);
+
+      const status = await rateLimiter.recordAttempt(testToken);
+
+      expect(mockPipeline.hincrby).toHaveBeenCalledWith(
+        `rate_limit:${testToken}:${getToday()}`,
+        'attemptsCount',
+        1,
+      );
+      expect(mockPipeline.expire).toHaveBeenCalled();
+      expect(status.rateLimits.attempts).toBe(1);
+    });
+
+    test('should increment success counters', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 1],
+        [null, 1],
+        [null, 'OK'],
+        [null, { attemptsCount: '1', deliveredCount: '1', errorCount: '0', totalCount: '1' }],
+      ]);
+
+      const rateLimits = await rateLimiter.recordSuccess(testToken);
+
+      expect(mockPipeline.hincrby).toHaveBeenCalledWith(
+        `rate_limit:${testToken}:${getToday()}`,
+        'deliveredCount',
+        1,
+      );
+      expect(mockPipeline.hincrby).toHaveBeenCalledWith(
+        `rate_limit:${testToken}:${getToday()}`,
+        'totalCount',
+        1,
+      );
+      expect(rateLimits.successful).toBe(1);
+      expect(rateLimits.total).toBe(1);
+    });
+
+    test('should increment error counters', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 1],
+        [null, 1],
+        [null, 'OK'],
+        [null, { attemptsCount: '1', deliveredCount: '0', errorCount: '1', totalCount: '1' }],
+      ]);
+
+      const rateLimits = await rateLimiter.recordError(testToken);
+
+      expect(mockPipeline.hincrby).toHaveBeenCalledWith(
+        `rate_limit:${testToken}:${getToday()}`,
+        'errorCount',
+        1,
+      );
+      expect(mockPipeline.hincrby).toHaveBeenCalledWith(
+        `rate_limit:${testToken}:${getToday()}`,
+        'totalCount',
+        1,
+      );
+      expect(rateLimits.errors).toBe(1);
+      expect(rateLimits.total).toBe(1);
+    });
+
+    test('should enforce rate limit', async () => {
+      const lowLimitRateLimiter = new RedisRateLimiter(5); // Low limit for testing
+
+      mockRedis.hgetall.mockResolvedValue({
+        attemptsCount: '5',
+        deliveredCount: '5',
+        errorCount: '0',
+        totalCount: '5',
+      });
+
+      const status = await lowLimitRateLimiter.checkRateLimit(testToken);
+
+      expect(status.isRateLimited).toBe(true);
+      expect(status.shouldSendRateLimitNotification).toBe(true);
+      expect(status.rateLimits.remaining).toBe(0);
+    });
+  });
+
+  describe('Redis key generation', () => {
+    test('should use correct Redis key format', async () => {
+      mockRedis.hgetall.mockResolvedValue({});
+
+      await rateLimiter.checkRateLimit(testToken);
+
+      expect(mockRedis.hgetall).toHaveBeenCalledWith(`rate_limit:${testToken}:${getToday()}`);
+    });
+
+    test('should set correct TTL for keys', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 1],
+        [null, 'OK'],
+        [null, { attemptsCount: '1', deliveredCount: '0', errorCount: '0', totalCount: '0' }],
+      ]);
+
+      await rateLimiter.recordAttempt(testToken);
+
+      // At 10:00 UTC, TTL should be 14 hours (50400 seconds) until end of day
+      expect(mockPipeline.expire).toHaveBeenCalledWith(
+        `rate_limit:${testToken}:${getToday()}`,
+        50400,
+      );
+    });
+  });
+
+  describe('Data parsing', () => {
+    test('should handle missing fields in Redis data', async () => {
+      mockRedis.hgetall.mockResolvedValue({
+        attemptsCount: '5',
+        // missing other fields
+      });
+
+      const status = await rateLimiter.checkRateLimit(testToken);
+
+      expect(status.rateLimits.attempts).toBe(5);
+      expect(status.rateLimits.successful).toBe(0);
+      expect(status.rateLimits.errors).toBe(0);
+      expect(status.rateLimits.total).toBe(0);
+    });
+
+    test('should handle non-numeric values gracefully', async () => {
+      mockRedis.hgetall.mockResolvedValue({
+        attemptsCount: 'invalid',
+        deliveredCount: 'abc',
+        errorCount: null,
+        totalCount: undefined,
+      });
+
+      const status = await rateLimiter.checkRateLimit(testToken);
+
+      expect(status.rateLimits.attempts).toBe(0);
+      expect(status.rateLimits.successful).toBe(0);
+      expect(status.rateLimits.errors).toBe(0);
+      expect(status.rateLimits.total).toBe(0);
+    });
+
+    test('should handle all fields present in Redis data', async () => {
+      mockRedis.hgetall.mockResolvedValue({
+        attemptsCount: '10',
+        deliveredCount: '8',
+        errorCount: '2',
+        totalCount: '10',
+      });
+
+      const status = await rateLimiter.checkRateLimit(testToken);
+
+      expect(status.rateLimits.attempts).toBe(10);
+      expect(status.rateLimits.successful).toBe(8);
+      expect(status.rateLimits.errors).toBe(2);
+      expect(status.rateLimits.total).toBe(10);
+    });
+
+    test('should handle completely empty Redis response', async () => {
+      mockRedis.hgetall.mockResolvedValue({});
+
+      const status = await rateLimiter.checkRateLimit(testToken);
+
+      expect(status.rateLimits.attempts).toBe(0);
+      expect(status.rateLimits.successful).toBe(0);
+      expect(status.rateLimits.errors).toBe(0);
+      expect(status.rateLimits.total).toBe(0);
+    });
+
+    test('should handle data fields in recordAttempt response', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 6],
+        [null, 'OK'],
+        [
+          null,
+          {
+            attemptsCount: '6',
+            deliveredCount: '5',
+            errorCount: '1',
+            totalCount: '6',
+          },
+        ],
+      ]);
+
+      const status = await rateLimiter.recordAttempt(testToken);
+
+      expect(status.rateLimits.attempts).toBe(6);
+      expect(status.rateLimits.successful).toBe(5);
+      expect(status.rateLimits.errors).toBe(1);
+      expect(status.rateLimits.total).toBe(6);
+    });
+
+    test('should handle data fields in recordSuccess response', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 6],
+        [null, 11],
+        [null, 'OK'],
+        [
+          null,
+          {
+            attemptsCount: '10',
+            deliveredCount: '6',
+            errorCount: '5',
+            totalCount: '11',
+          },
+        ],
+      ]);
+
+      const rateLimits = await rateLimiter.recordSuccess(testToken);
+
+      expect(rateLimits.attempts).toBe(10);
+      expect(rateLimits.successful).toBe(6);
+      expect(rateLimits.errors).toBe(5);
+      expect(rateLimits.total).toBe(11);
+    });
+
+    test('should handle data fields in recordError response', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 3],
+        [null, 8],
+        [null, 'OK'],
+        [
+          null,
+          {
+            attemptsCount: '8',
+            deliveredCount: '5',
+            errorCount: '3',
+            totalCount: '8',
+          },
+        ],
+      ]);
+
+      const rateLimits = await rateLimiter.recordError(testToken);
+
+      expect(rateLimits.attempts).toBe(8);
+      expect(rateLimits.successful).toBe(5);
+      expect(rateLimits.errors).toBe(3);
+      expect(rateLimits.total).toBe(8);
+    });
+  });
+
+  describe('Error handling', () => {
+    test('should handle Redis connection errors', async () => {
+      mockRedis.hgetall.mockRejectedValue(new Error('Redis connection failed'));
+
+      await expect(rateLimiter.checkRateLimit(testToken)).rejects.toThrow(
+        'Redis connection failed',
+      );
+    });
+
+    test('should handle pipeline execution errors', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockRejectedValue(new Error('Pipeline execution failed'));
+
+      await expect(rateLimiter.recordAttempt(testToken)).rejects.toThrow(
+        'Pipeline execution failed',
+      );
+    });
+  });
+
+  describe('Connection management', () => {
+    test('should close Redis connection', async () => {
+      mockRedis.quit.mockResolvedValue('OK');
+
+      await rateLimiter.close();
+
+      expect(mockRedis.quit).toHaveBeenCalled();
+    });
+  });
+
+  describe('Rate limit edge cases', () => {
+    test('should handle negative remaining count', async () => {
+      mockRedis.hgetall.mockResolvedValue({
+        attemptsCount: '10',
+        deliveredCount: '200', // More than max allowed
+        errorCount: '0',
+        totalCount: '200',
+      });
+
+      const status = await rateLimiter.checkRateLimit(testToken);
+
+      expect(status.rateLimits.remaining).toBe(0);
+      expect(status.isRateLimited).toBe(true);
+    });
+
+    test('should calculate positive remaining count correctly', async () => {
+      mockRedis.hgetall.mockResolvedValue({
+        attemptsCount: '50',
+        deliveredCount: '50',
+        errorCount: '0',
+        totalCount: '50',
+      });
+
+      const status = await rateLimiter.checkRateLimit(testToken);
+
+      expect(status.rateLimits.remaining).toBe(100); // 150 - 50 = 100
+      expect(status.isRateLimited).toBe(false);
+    });
+
+    test('resetsAt should show next day midnight', async () => {
+      mockRedis.hgetall.mockResolvedValue({});
+
+      const status = await rateLimiter.checkRateLimit(testToken);
+
+      // We're at 2024-01-01T10:00:00Z, so reset should be at 2024-01-02T00:00:00Z
+      expect(status.rateLimits.resetsAt).toEqual(new Date('2024-01-02T00:00:00.000Z'));
+    });
+  });
+
+  describe('Multiple tokens', () => {
+    test('should handle multiple different tokens independently', async () => {
+      const token1 = 'token-1';
+      const token2 = 'token-2';
+
+      // Set up different responses for different tokens
+      mockRedis.hgetall.mockImplementation((key) => {
+        if (key.includes(token1)) {
+          return Promise.resolve({
+            attemptsCount: '5',
+            deliveredCount: '3',
+            errorCount: '2',
+            totalCount: '5',
+          });
+        } else if (key.includes(token2)) {
+          return Promise.resolve({
+            attemptsCount: '10',
+            deliveredCount: '8',
+            errorCount: '2',
+            totalCount: '10',
+          });
+        }
+        return Promise.resolve({});
+      });
+
+      const status1 = await rateLimiter.checkRateLimit(token1);
+      const status2 = await rateLimiter.checkRateLimit(token2);
+
+      expect(status1.rateLimits.attempts).toBe(5);
+      expect(status1.rateLimits.successful).toBe(3);
+      expect(status2.rateLimits.attempts).toBe(10);
+      expect(status2.rateLimits.successful).toBe(8);
+    });
+  });
+
+  describe('Date boundary handling', () => {
+    test('should use correct date at year boundary', async () => {
+      jest.setSystemTime(new Date('2023-12-31T23:59:59Z'));
+      mockRedis.hgetall.mockResolvedValue({});
+
+      await rateLimiter.checkRateLimit(testToken);
+
+      expect(mockRedis.hgetall).toHaveBeenCalledWith(`rate_limit:${testToken}:20231231`);
+    });
+
+    test('should calculate correct TTL near midnight', async () => {
+      jest.setSystemTime(new Date('2024-01-01T23:59:00Z'));
+
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 1],
+        [null, 'OK'],
+        [null, { attemptsCount: '1', deliveredCount: '0', errorCount: '0', totalCount: '0' }],
+      ]);
+
+      await rateLimiter.recordAttempt(testToken);
+
+      // 1 minute until midnight = 60 seconds
+      expect(mockPipeline.expire).toHaveBeenCalledWith(`rate_limit:${testToken}:${getToday()}`, 60);
+    });
+  });
+
+  describe('Redis connection and retry strategy', () => {
+    test('should initialize with custom Redis host and port', () => {
+      const customHost = 'redis.example.com';
+      const customPort = 6380;
+
+      // Create a new instance with custom host and port
+      new RedisRateLimiter(maxNotificationsPerDay, false, customHost, customPort);
+
+      expect(Redis).toHaveBeenCalledWith({
+        host: customHost,
+        port: customPort,
+        retryStrategy: expect.any(Function),
+      });
+    });
+
+    test('should have proper retry strategy', () => {
+      // retryStrategyFn was captured during beforeEach
+      expect(retryStrategyFn).toBeDefined();
+
+      // Test retry strategy with different attempt counts
+      expect(retryStrategyFn(1)).toBe(50); // 1 * 50 = 50
+      expect(retryStrategyFn(10)).toBe(500); // 10 * 50 = 500
+      expect(retryStrategyFn(40)).toBe(2000); // 40 * 50 = 2000 (capped)
+      expect(retryStrategyFn(50)).toBe(2000); // 50 * 50 = 2500 -> capped at 2000
+      expect(retryStrategyFn(100)).toBe(2000); // 100 * 50 = 5000 -> capped at 2000
+    });
+
+    test('should handle debug parameter', () => {
+      // Create instance with debug enabled
+      const debugRateLimiter = new RedisRateLimiter(maxNotificationsPerDay, true);
+      expect(debugRateLimiter.debug).toBe(true);
+
+      // Default instance should have debug disabled
+      expect(rateLimiter.debug).toBe(false);
+    });
+  });
+
+  describe('Constructor defaults', () => {
+    test('should use default Redis connection parameters', () => {
+      // Clear previous mock calls
+      Redis.mockClear();
+
+      // Create instance without specifying host/port
+      new RedisRateLimiter(maxNotificationsPerDay);
+
+      expect(Redis).toHaveBeenCalledWith({
+        host: 'localhost',
+        port: 6379,
+        retryStrategy: expect.any(Function),
+      });
+    });
+  });
+
+  describe('_getRateLimitsObject edge cases', () => {
+    test('should handle doc with zero values', async () => {
+      // Create a scenario where _getRateLimitsObject is called with all zeros
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 1],
+        [null, 'OK'],
+        [
+          null,
+          {
+            attemptsCount: '0',
+            deliveredCount: '0',
+            errorCount: '0',
+            totalCount: '0',
+          },
+        ],
+      ]);
+
+      const status = await rateLimiter.recordAttempt(testToken);
+
+      // The values should be parsed correctly even with zeros
+      expect(status.rateLimits.attempts).toBe(0);
+      expect(status.rateLimits.successful).toBe(0);
+      expect(status.rateLimits.errors).toBe(0);
+      expect(status.rateLimits.total).toBe(0);
+    });
+
+    test('should handle empty strings in pipeline results', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 1],
+        [null, 1],
+        [null, 'OK'],
+        [
+          null,
+          {
+            attemptsCount: '',
+            deliveredCount: '',
+            errorCount: '',
+            totalCount: '',
+          },
+        ],
+      ]);
+
+      const rateLimits = await rateLimiter.recordSuccess(testToken);
+
+      expect(rateLimits.attempts).toBe(0);
+      expect(rateLimits.successful).toBe(0);
+      expect(rateLimits.errors).toBe(0);
+      expect(rateLimits.total).toBe(0);
+    });
+
+    test('should handle missing fields in recordAttempt pipeline result', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 1],
+        [null, 'OK'],
+        [
+          null,
+          {
+            // All fields missing - tests the || '0' branches
+          },
+        ],
+      ]);
+
+      const status = await rateLimiter.recordAttempt(testToken);
+
+      expect(status.rateLimits.attempts).toBe(0);
+      expect(status.rateLimits.successful).toBe(0);
+      expect(status.rateLimits.errors).toBe(0);
+      expect(status.rateLimits.total).toBe(0);
+    });
+
+    test('should handle missing fields in recordError pipeline result', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 1],
+        [null, 1],
+        [null, 'OK'],
+        [
+          null,
+          {
+            // All fields missing - tests the || '0' branches
+          },
+        ],
+      ]);
+
+      const rateLimits = await rateLimiter.recordError(testToken);
+
+      expect(rateLimits.attempts).toBe(0);
+      expect(rateLimits.successful).toBe(0);
+      expect(rateLimits.errors).toBe(0);
+      expect(rateLimits.total).toBe(0);
+    });
+
+    test('should handle undefined values in recordSuccess pipeline result', async () => {
+      const mockPipeline = mockRedis.pipeline();
+      mockPipeline.exec.mockResolvedValue([
+        [null, 1],
+        [null, 1],
+        [null, 'OK'],
+        [
+          null,
+          {
+            attemptsCount: undefined,
+            deliveredCount: undefined,
+            errorCount: undefined,
+            totalCount: undefined,
+          },
+        ],
+      ]);
+
+      const rateLimits = await rateLimiter.recordSuccess(testToken);
+
+      expect(rateLimits.attempts).toBe(0);
+      expect(rateLimits.successful).toBe(0);
+      expect(rateLimits.errors).toBe(0);
+      expect(rateLimits.total).toBe(0);
+    });
+  });
+});

--- a/functions/test/rate-limiter/redis-rate-limiter.test.js
+++ b/functions/test/rate-limiter/redis-rate-limiter.test.js
@@ -53,7 +53,6 @@ describe('RedisRateLimiter', () => {
     jest.restoreAllMocks();
   });
 
-
   describe('Basic functionality', () => {
     test('should initialize with zero counts', async () => {
       mockRedis.hgetall.mockResolvedValue({});

--- a/functions/test/utils/mock-factories.js
+++ b/functions/test/utils/mock-factories.js
@@ -164,7 +164,6 @@ class MockDataManager {
   }
 }
 
-
 module.exports = {
   createMockRequest,
   createMockResponse,

--- a/functions/test/utils/mock-factories.js
+++ b/functions/test/utils/mock-factories.js
@@ -164,16 +164,6 @@ class MockDataManager {
   }
 }
 
-/**
- * Gets today's date in YYYYMMDD format
- */
-const getToday = () => {
-  const today = new Date();
-  const dd = String(today.getDate()).padStart(2, '0');
-  const mm = String(today.getMonth() + 1).padStart(2, '0');
-  const yyyy = today.getFullYear();
-  return yyyy + mm + dd;
-};
 
 module.exports = {
   createMockRequest,
@@ -185,5 +175,4 @@ module.exports = {
   createMockRateLimitData,
   setupFirestoreCollectionChain,
   MockDataManager,
-  getToday,
 };


### PR DESCRIPTION
Adds a Redis based rate-limiter that will be used if REDIS_HOST and REDIS_PORT are defined in the environment.

Note that Redis is now configured in the GCP account and REDIS_HOST/REDIS_PORT have been defined in the Cloud Function environments here, so upon merge this will begin using Redis.