### PR TITLE
Revert "Bump w9jds/firebase-action from 14.10.1 to 14.11.0"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           cd functions
           npm install
       - name: Deploy to Firebase
-        uses: w9jds/firebase-action@v14.11.0
+        uses: w9jds/firebase-action@v14.10.1
         with:
           args: deploy
         env:


### PR DESCRIPTION
Reverts #217 because of https://github.com/w9jds/firebase-action/issues/252