### PR TITLE
whitelist command_health_connect_write payload keys

### DIFF
--- a/functions/android.js
+++ b/functions/android.js
@@ -109,6 +109,22 @@ module.exports = {
         'progress_indeterminate',
         'live_update',
         'critical_text',
+        // Fields used by command_health_connect_write — without these in the
+        // whitelist they get dropped from the FCM payload and the device-side
+        // handler can't find data_type/value/etc.
+        'data_type',
+        'value',
+        'unit',
+        'time',
+        'start_time',
+        'end_time',
+        'systolic',
+        'diastolic',
+        'samples',
+        'stages',
+        'exercise_type',
+        'notes',
+        'client_record_id',
       ];
 
       androidNotificationKeys.forEach((key) => {
@@ -146,6 +162,7 @@ module.exports = {
         'command_screen_off_timeout',
         'command_flashlight',
         'command_wake_word_detection',
+        'command_health_connect_write',
       ];
       if (androidMessagesToIgnore.includes(req.body.message)) {
         updateRateLimits = false;


### PR DESCRIPTION
companion to the new `command_health_connect_write` push command being added in [home-assistant/android#6799](https://github.com/home-assistant/android/pull/6799). without this whitelist update HC payloads sent through this proxy lose all their fields by the time they reach the device.

## changes

**`functions/android.js`**

1. adds the HC write fields to `androidNotificationKeys` so they actually make it into `payload.data`:
   - `data_type`, `value`, `unit`, `time`, `start_time`, `end_time` — common fields
   - `systolic`, `diastolic` — blood pressure record
   - `samples`, `stages` — series records (heart rate samples, sleep stages, speed/power/cadence)
   - `exercise_type`, `notes` — exercise sessions
   - `client_record_id` — idempotency key

2. adds `command_health_connect_write` to `androidMessagesToIgnore` so HC writes don't count against the daily 500-notification rate limit. matches the existing treatment of every other `command_*` message — they're commands, not user-visible notifications.

## related

- depends on [home-assistant/android#6799](https://github.com/home-assistant/android/pull/6799) defining the wire format. happy to hold this until that lands or merges, whichever you prefer.
- independent of [#294](https://github.com/home-assistant/mobile-apps-fcm-push/pull/294), but #294 is required for the array-typed fields here (`samples`, `stages`) to round-trip correctly. otherwise primitives work fine on their own.
