### PR TITLE
Support iOS camera notification commands

### DIFF
--- a/functions/ios.js
+++ b/functions/ios.js
@@ -41,25 +41,31 @@ module.exports = {
     let updateRateLimits = true;
 
     if (req.body.registration_info.app_id.indexOf('io.robbie.HomeAssistant') > -1) {
+      const addCommand = (command) => {
+        payload.notification = {};
+        payload.apns.payload.aps = {};
+        payload.apns.payload.aps.contentAvailable = true;
+        payload.apns.payload.homeassistant = { command: command };
+        updateRateLimits = false;
+      };
+
       // Enable old SNS iOS specific push setup.
       if (
         req.body.message === 'request_location_update' ||
         req.body.message === 'request_location_updates'
       ) {
-        payload.notification = {};
-        payload.apns.payload.aps = {};
-        payload.apns.payload.aps.contentAvailable = true;
-        payload.apns.payload.homeassistant = {
-          command: 'request_location_update',
-        };
-        updateRateLimits = false;
+        addCommand('request_location_update');
       } else if (req.body.message === 'clear_badge') {
-        payload.notification = {};
-        payload.apns.payload.aps = {};
-        payload.apns.payload.aps.contentAvailable = true;
+        addCommand('clear_badge');
         payload.apns.payload.aps.badge = 0;
-        payload.apns.payload.homeassistant = { command: 'clear_badge' };
-        updateRateLimits = false;
+      } else if (req.body.message === 'show_camera') {
+        addCommand('show_camera');
+
+        if (req.body.data?.entity_id) {
+          payload.apns.payload.homeassistant.entity_id = req.body.data.entity_id;
+        }
+      } else if (req.body.message === 'hide_camera') {
+        addCommand('hide_camera');
       } else {
         if (req.body.data) {
           if (req.body.data.subtitle) {

--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -96,6 +96,14 @@ module.exports = {
       } else if (req.body.message === 'update_widgets') {
         addCommand('update_widgets');
         updateRateLimits = false;
+      } else if (req.body.message === 'show_camera') {
+        addCommand('show_camera');
+
+        if (req.body.data?.entity_id) {
+          payload.apns.payload.homeassistant.entity_id = req.body.data.entity_id;
+        }
+      } else if (req.body.message === 'hide_camera') {
+        addCommand('hide_camera');
       } else {
         let needsCategory = false;
         let needsMutableContent = false;

--- a/functions/test/fixtures/legacy/command_hide_camera.json
+++ b/functions/test/fixtures/legacy/command_hide_camera.json
@@ -1,0 +1,23 @@
+{
+  "input": {
+    "title": "extra excluded title",
+    "message": "hide_camera",
+    "registration_info": {
+      "app_id": "io.robbie.HomeAssistant.dev",
+      "os_version": "18.0",
+      "app_version": "2026.1"
+    }
+  },
+  "rate_limit": false,
+  "headers": {
+    "apns-push-type": "background"
+  },
+  "payload": {
+    "aps": {
+      "contentAvailable": true
+    },
+    "homeassistant": {
+      "command": "hide_camera"
+    }
+  }
+}

--- a/functions/test/fixtures/legacy/command_show_camera.json
+++ b/functions/test/fixtures/legacy/command_show_camera.json
@@ -1,0 +1,27 @@
+{
+  "input": {
+    "title": "extra excluded title",
+    "message": "show_camera",
+    "data": {
+      "entity_id": "camera.front_door"
+    },
+    "registration_info": {
+      "app_id": "io.robbie.HomeAssistant.dev",
+      "os_version": "18.0",
+      "app_version": "2026.1"
+    }
+  },
+  "rate_limit": false,
+  "headers": {
+    "apns-push-type": "background"
+  },
+  "payload": {
+    "aps": {
+      "contentAvailable": true
+    },
+    "homeassistant": {
+      "command": "show_camera",
+      "entity_id": "camera.front_door"
+    }
+  }
+}

--- a/functions/test/ios.test.js
+++ b/functions/test/ios.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const ios = require('../ios.js');
+
+describe('ios.js', () => {
+  it('should create a silent show_camera command with entity_id', () => {
+    const result = ios.createPayload({
+      body: {
+        message: 'show_camera',
+        data: {
+          entity_id: 'camera.front_door',
+        },
+        registration_info: {
+          app_id: 'io.robbie.HomeAssistant.dev',
+          os_version: '18.0',
+          app_version: '2026.1',
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      updateRateLimits: false,
+      payload: {
+        notification: {},
+        apns: {
+          headers: {
+            'apns-push-type': 'background',
+          },
+          payload: {
+            aps: {
+              contentAvailable: true,
+            },
+            homeassistant: {
+              command: 'show_camera',
+              entity_id: 'camera.front_door',
+            },
+          },
+        },
+        fcm_options: {
+          analytics_label: 'iosV1Notification',
+        },
+      },
+    });
+  });
+
+  it('should create a silent hide_camera command', () => {
+    const result = ios.createPayload({
+      body: {
+        message: 'hide_camera',
+        registration_info: {
+          app_id: 'io.robbie.HomeAssistant.dev',
+          os_version: '18.0',
+          app_version: '2026.1',
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      updateRateLimits: false,
+      payload: {
+        notification: {},
+        apns: {
+          headers: {
+            'apns-push-type': 'background',
+          },
+          payload: {
+            aps: {
+              contentAvailable: true,
+            },
+            homeassistant: {
+              command: 'hide_camera',
+            },
+          },
+        },
+        fcm_options: {
+          analytics_label: 'iosV1Notification',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add iOS FCM payload support for `show_camera` and `hide_camera` notification commands.
- Ensure `show_camera` is delivered as a silent/background APNs command with `entity_id` under `homeassistant`.
- Keep `hide_camera` parameterless and silent.
- Add focused `ios.js` coverage and legacy payload fixtures for both commands.

iOS: https://github.com/home-assistant/iOS/pull/4688
docs: https://github.com/home-assistant/companion.home-assistant/pull/1338