### PR TITLE
Add webhook id and url as live activity options

### DIFF
--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -57,6 +57,12 @@ function createPayload(req) {
       tag: data.activity_id ?? data.tag ?? '',
       title: req.body.title ?? '',
     };
+    // Server that started the activity, so a tap can open the originating server when the
+    // user has several. Only sent when present; the iOS attribute is optional for compatibility.
+    const startWebhookId = req.body.registration_info && req.body.registration_info.webhook_id;
+    if (startWebhookId) {
+      aps.attributes.webhook_id = startWebhookId;
+    }
   }
 
   if (event === LiveActivityEvent.END) {
@@ -158,6 +164,8 @@ function buildContentState(body, data) {
   if (data.chronometer !== undefined) state.chronometer = data.chronometer;
   if (data.notification_icon !== undefined) state.icon = data.notification_icon;
   if (data.notification_icon_color !== undefined) state.color = data.notification_icon_color;
+  // url: path/URL to open when the activity is tapped (mirrors actionable notifications).
+  if (data.url !== undefined) state.url = data.url;
   if (data.when !== undefined) {
     state.countdown_end = data.when_relative
       ? Math.floor(Date.now() / 1000) + data.when
@@ -175,6 +183,7 @@ function buildContentState(body, data) {
     if (cs.countdown_end !== undefined) state.countdown_end = cs.countdown_end;
     if (cs.icon !== undefined) state.icon = cs.icon;
     if (cs.color !== undefined) state.color = cs.color;
+    if (cs.url !== undefined) state.url = cs.url;
   }
 
   return state;

--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -164,7 +164,6 @@ function buildContentState(body, data) {
   if (data.chronometer !== undefined) state.chronometer = data.chronometer;
   if (data.notification_icon !== undefined) state.icon = data.notification_icon;
   if (data.notification_icon_color !== undefined) state.color = data.notification_icon_color;
-  // url: path/URL to open when the activity is tapped (mirrors actionable notifications).
   if (data.url !== undefined) state.url = data.url;
   if (data.when !== undefined) {
     state.countdown_end = data.when_relative

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -250,6 +250,52 @@ describe('live-activity createPayload via FCM', () => {
     expect(payload.apns.payload.aps.attributes).toEqual({ tag: 'laundry-001', title: 'Laundry' });
   });
 
+  test('start event includes webhook_id in attributes when registration_info has one', () => {
+    const req = createMockRequest({
+      body: {
+        push_token: FCM_TOKEN,
+        live_activity_token: LIVE_ACTIVITY_TOKEN,
+        title: 'Laundry',
+        registration_info: { app_id: 'io.robbie.HomeAssistant', webhook_id: 'wh-123' },
+        data: { event: 'start', activity_id: 'laundry-001' },
+      },
+    });
+    const { payload } = legacy.createPayload(req);
+    expect(payload.apns.payload.aps.attributes).toEqual({
+      tag: 'laundry-001',
+      title: 'Laundry',
+      webhook_id: 'wh-123',
+    });
+  });
+
+  test('start event omits webhook_id from attributes when registration_info lacks one', () => {
+    const req = createMockRequest({
+      body: {
+        push_token: FCM_TOKEN,
+        live_activity_token: LIVE_ACTIVITY_TOKEN,
+        title: 'Laundry',
+        registration_info: { app_id: 'io.robbie.HomeAssistant' },
+        data: { event: 'start', activity_id: 'laundry-001' },
+      },
+    });
+    const { payload } = legacy.createPayload(req);
+    expect(payload.apns.payload.aps.attributes.webhook_id).toBeUndefined();
+  });
+
+  test('url in data is forwarded into content-state for tap navigation', () => {
+    const req = createMockRequest({
+      body: {
+        push_token: FCM_TOKEN,
+        live_activity_token: LIVE_ACTIVITY_TOKEN,
+        message: 'Laundry running',
+        registration_info: { app_id: 'io.robbie.HomeAssistant' },
+        data: { event: 'update', url: '/lovelace/laundry' },
+      },
+    });
+    const { payload } = legacy.createPayload(req);
+    expect(payload.apns.payload.aps['content-state'].url).toBe('/lovelace/laundry');
+  });
+
   test('start event synthesizes alert without sound when alert is omitted', () => {
     const req = createMockRequest({
       body: {


### PR DESCRIPTION
PR adds webhook id so iOS app can identify where the Live activity starts from and open the correct server when tapped.
PR also adds URL key to the live activity content state as an options to define what to open when tapping on it