### PR TITLE
Forward background_color and text_color into Live Activity content-state

### DIFF
--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -165,6 +165,7 @@ function buildContentState(body, data) {
   if (data.notification_icon !== undefined) state.icon = data.notification_icon;
   if (data.notification_icon_color !== undefined) state.color = data.notification_icon_color;
   if (data.background_color !== undefined) state.background_color = data.background_color;
+  if (data.text_color !== undefined) state.text_color = data.text_color;
   if (data.url !== undefined) state.url = data.url;
   if (data.when !== undefined) {
     state.countdown_end = data.when_relative
@@ -184,6 +185,7 @@ function buildContentState(body, data) {
     if (cs.icon !== undefined) state.icon = cs.icon;
     if (cs.color !== undefined) state.color = cs.color;
     if (cs.background_color !== undefined) state.background_color = cs.background_color;
+    if (cs.text_color !== undefined) state.text_color = cs.text_color;
     if (cs.url !== undefined) state.url = cs.url;
   }
 

--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -164,6 +164,7 @@ function buildContentState(body, data) {
   if (data.chronometer !== undefined) state.chronometer = data.chronometer;
   if (data.notification_icon !== undefined) state.icon = data.notification_icon;
   if (data.notification_icon_color !== undefined) state.color = data.notification_icon_color;
+  if (data.background_color !== undefined) state.background_color = data.background_color;
   if (data.url !== undefined) state.url = data.url;
   if (data.when !== undefined) {
     state.countdown_end = data.when_relative
@@ -182,6 +183,7 @@ function buildContentState(body, data) {
     if (cs.countdown_end !== undefined) state.countdown_end = cs.countdown_end;
     if (cs.icon !== undefined) state.icon = cs.icon;
     if (cs.color !== undefined) state.color = cs.color;
+    if (cs.background_color !== undefined) state.background_color = cs.background_color;
     if (cs.url !== undefined) state.url = cs.url;
   }
 

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -296,6 +296,20 @@ describe('live-activity createPayload via FCM', () => {
     expect(payload.apns.payload.aps['content-state'].url).toBe('/lovelace/laundry');
   });
 
+  test('background_color in data is forwarded into content-state', () => {
+    const req = createMockRequest({
+      body: {
+        push_token: FCM_TOKEN,
+        live_activity_token: LIVE_ACTIVITY_TOKEN,
+        message: 'Laundry running',
+        registration_info: { app_id: 'io.robbie.HomeAssistant' },
+        data: { event: 'update', background_color: '#101820' },
+      },
+    });
+    const { payload } = legacy.createPayload(req);
+    expect(payload.apns.payload.aps['content-state'].background_color).toBe('#101820');
+  });
+
   test('start event synthesizes alert without sound when alert is omitted', () => {
     const req = createMockRequest({
       body: {
@@ -424,6 +438,7 @@ describe('live-activity createPayload via FCM', () => {
           chronometer: true,
           notification_icon: 'mdi:washing-machine',
           notification_icon_color: '#2196F3',
+          background_color: '#101820',
         },
       },
     });
@@ -437,6 +452,7 @@ describe('live-activity createPayload via FCM', () => {
       chronometer: true,
       icon: 'mdi:washing-machine',
       color: '#2196F3',
+      background_color: '#101820',
     });
   });
 

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -439,6 +439,7 @@ describe('live-activity createPayload via FCM', () => {
           notification_icon: 'mdi:washing-machine',
           notification_icon_color: '#2196F3',
           background_color: '#101820',
+          text_color: '#FFFFFF',
         },
       },
     });
@@ -453,6 +454,7 @@ describe('live-activity createPayload via FCM', () => {
       icon: 'mdi:washing-machine',
       color: '#2196F3',
       background_color: '#101820',
+      text_color: '#FFFFFF',
     });
   });
 


### PR DESCRIPTION
## Summary

Adds `background_color` and `text_color` to the Live Activity content-state the relay builds, mirroring how `notification_icon_color` is forwarded. The iOS companion app uses them to set the Lock Screen background (default black) and foreground of a Live Activity, parsed with the same rules as `notification_icon_color`.

Both input paths are handled for each field:
- top-level `data.background_color` / `data.text_color`
- `data.content_state.*` (explicit override)

Pairs with the iOS change: home-assistant/iOS#4815.

<img width="603" height="1311" alt="Screenshot 2026-06-23 at 20 53 50" src="https://github.com/user-attachments/assets/bdcf1874-0b8c-479b-bce5-27ec72b6bb9e" />
