### PR TITLE
Forward progress_bar_color into Live Activity content-state

### DIFF
--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -166,6 +166,7 @@ function buildContentState(body, data) {
   if (data.notification_icon_color !== undefined) state.color = data.notification_icon_color;
   if (data.background_color !== undefined) state.background_color = data.background_color;
   if (data.text_color !== undefined) state.text_color = data.text_color;
+  if (data.progress_bar_color !== undefined) state.progress_bar_color = data.progress_bar_color;
   if (data.url !== undefined) state.url = data.url;
   if (data.when !== undefined) {
     state.countdown_end = data.when_relative
@@ -186,6 +187,7 @@ function buildContentState(body, data) {
     if (cs.color !== undefined) state.color = cs.color;
     if (cs.background_color !== undefined) state.background_color = cs.background_color;
     if (cs.text_color !== undefined) state.text_color = cs.text_color;
+    if (cs.progress_bar_color !== undefined) state.progress_bar_color = cs.progress_bar_color;
     if (cs.url !== undefined) state.url = cs.url;
   }
 

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -440,6 +440,7 @@ describe('live-activity createPayload via FCM', () => {
           notification_icon_color: '#2196F3',
           background_color: '#101820',
           text_color: '#FFFFFF',
+          progress_bar_color: '#FF9800',
         },
       },
     });
@@ -455,6 +456,7 @@ describe('live-activity createPayload via FCM', () => {
       color: '#2196F3',
       background_color: '#101820',
       text_color: '#FFFFFF',
+      progress_bar_color: '#FF9800',
     });
   });
 


### PR DESCRIPTION
## Summary

Adds `progress_bar_color` to the Live Activity content-state the relay builds, mirroring the existing color fields. The iOS companion app uses it to tint the Live Activity progress bar, falling back to `notification_icon_color` when omitted.

Both input paths are handled:
- top-level `data.progress_bar_color`
- `data.content_state.progress_bar_color` (explicit override)

Pairs with the iOS change; docs in home-assistant/companion.home-assistant#1303.