### PR TITLE
Add notification_icon_color to supported keys on Android

### DIFF
--- a/functions/android.js
+++ b/functions/android.js
@@ -49,6 +49,7 @@ module.exports = {
       const androidNotificationKeys = [
         'icon',
         'color',
+        'notification_icon_color',
         'sound',
         'tag',
         'clickAction',


### PR DESCRIPTION
PR to accompany the change in https://github.com/home-assistant/android/pull/7091