### PR TITLE
Forward level/volume for kiosk_set_brightness and kiosk_set_volume commands

### DIFF
--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -162,8 +162,7 @@ module.exports = {
             needsMutableContent = true;
           }
 
-          // Kiosk command values (kiosk_set_brightness / kiosk_set_volume). Checked with
-          // !== undefined so a value of 0 (mute / minimum brightness) is preserved.
+          // Kiosk command values (kiosk_set_brightness / kiosk_set_volume)
           if (req.body.data.level !== undefined) {
             payload.apns.payload.level = req.body.data.level;
           }

--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -162,12 +162,13 @@ module.exports = {
             needsMutableContent = true;
           }
 
-          // Kiosk command values (kiosk_set_brightness / kiosk_set_volume)
           if (req.body.data.level !== undefined) {
+            // Kiosk command value for kiosk_set_brightness
             payload.apns.payload.level = req.body.data.level;
           }
 
           if (req.body.data.volume !== undefined) {
+            // Kiosk command value for kiosk_set_volume
             payload.apns.payload.volume = req.body.data.volume;
           }
 

--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -162,6 +162,16 @@ module.exports = {
             needsMutableContent = true;
           }
 
+          // Kiosk command values (kiosk_set_brightness / kiosk_set_volume). Checked with
+          // !== undefined so a value of 0 (mute / minimum brightness) is preserved.
+          if (req.body.data.level !== undefined) {
+            payload.apns.payload.level = req.body.data.level;
+          }
+
+          if (req.body.data.volume !== undefined) {
+            payload.apns.payload.volume = req.body.data.volume;
+          }
+
           if (req.body.data.action_data) {
             payload.apns.payload.homeassistant = req.body.data.action_data;
             needsCategory = true;

--- a/functions/test/fixtures/legacy/kiosk_set_brightness.json
+++ b/functions/test/fixtures/legacy/kiosk_set_brightness.json
@@ -1,0 +1,26 @@
+{
+  "input": {
+    "message": "kiosk_set_brightness",
+    "data": {
+      "level": 50
+    },
+    "registration_info": {
+      "app_id": "io.robbie.HomeAssistant.dev",
+      "os_version": "10.15",
+      "app_version": "2021.5"
+    }
+  },
+  "rate_limit": true,
+  "headers": {
+    "apns-push-type": "alert"
+  },
+  "payload": {
+    "aps": {
+      "alert": {
+        "body": "kiosk_set_brightness"
+      },
+      "sound": "default"
+    },
+    "level": 50
+  }
+}

--- a/functions/test/fixtures/legacy/kiosk_set_volume.json
+++ b/functions/test/fixtures/legacy/kiosk_set_volume.json
@@ -1,0 +1,26 @@
+{
+  "input": {
+    "message": "kiosk_set_volume",
+    "data": {
+      "volume": 100
+    },
+    "registration_info": {
+      "app_id": "io.robbie.HomeAssistant.dev",
+      "os_version": "10.15",
+      "app_version": "2021.5"
+    }
+  },
+  "rate_limit": true,
+  "headers": {
+    "apns-push-type": "alert"
+  },
+  "payload": {
+    "aps": {
+      "alert": {
+        "body": "kiosk_set_volume"
+      },
+      "sound": "default"
+    },
+    "volume": 100
+  }
+}


### PR DESCRIPTION
Forwards the `level` and `volume` values from the notification `data` into the iOS APNS payload, so the companion app's new `kiosk_set_brightness` / `kiosk_set_volume` push commands receive their value. Today these keys are stripped, like any non-whitelisted `data` key.

Companion to home-assistant/iOS#4845.
