### PR TITLE
Set apns-collapse-id on Live Activity start pushes

### DIFF
--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -112,15 +112,27 @@ function createPayload(req) {
     );
   }
 
+  const headers = {
+    'apns-priority': APNS_PRIORITY_IMMEDIATE,
+  };
+
+  // Coalesce duplicate start pushes for the same activity. If several starts for the same
+  // activity are queued by APNs while the device is offline, the collapse identifier makes
+  // APNs deliver only the most recent one, so the user ends up with a single Live Activity
+  // instead of several. Scoped to start events on purpose: updates and ends must each be
+  // delivered so the activity reflects its latest state and can be dismissed.
+  const collapseId = data.activity_id ?? data.tag;
+  if (event === LiveActivityEvent.START && collapseId) {
+    headers['apns-collapse-id'] = collapseId;
+  }
+
   const payload = {
     apns: {
       // The liveActivityToken (camelCase) tells Firebase Admin SDK v13.5.0+ to route
       // this message as a Live Activity notification. FCM automatically sets the
       // apns-push-type: liveactivity header and the correct apns-topic suffix.
       liveActivityToken: req.body.live_activity_token,
-      headers: {
-        'apns-priority': APNS_PRIORITY_IMMEDIATE,
-      },
+      headers,
       payload: {
         aps,
       },

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -282,6 +282,62 @@ describe('live-activity createPayload via FCM', () => {
     expect(payload.apns.payload.aps.attributes.webhook_id).toBeUndefined();
   });
 
+  test('start event sets apns-collapse-id to the activity id so duplicate starts coalesce', () => {
+    const req = createMockRequest({
+      body: {
+        push_token: FCM_TOKEN,
+        live_activity_token: LIVE_ACTIVITY_TOKEN,
+        title: 'Laundry',
+        registration_info: { app_id: 'io.robbie.HomeAssistant' },
+        data: { event: 'start', activity_id: 'laundry-001' },
+      },
+    });
+    const { payload } = legacy.createPayload(req);
+    expect(payload.apns.headers['apns-collapse-id']).toBe('laundry-001');
+  });
+
+  test('start event falls back to tag for apns-collapse-id when activity_id is absent', () => {
+    const req = createMockRequest({
+      body: {
+        push_token: FCM_TOKEN,
+        live_activity_token: LIVE_ACTIVITY_TOKEN,
+        title: 'Laundry',
+        registration_info: { app_id: 'io.robbie.HomeAssistant' },
+        data: { event: 'start', tag: 'laundry-tag' },
+      },
+    });
+    const { payload } = legacy.createPayload(req);
+    expect(payload.apns.headers['apns-collapse-id']).toBe('laundry-tag');
+  });
+
+  test('start event omits apns-collapse-id when no activity id or tag is provided', () => {
+    const req = createMockRequest({
+      body: {
+        push_token: FCM_TOKEN,
+        live_activity_token: LIVE_ACTIVITY_TOKEN,
+        title: 'Laundry',
+        registration_info: { app_id: 'io.robbie.HomeAssistant' },
+        data: { event: 'start' },
+      },
+    });
+    const { payload } = legacy.createPayload(req);
+    expect(payload.apns.headers['apns-collapse-id']).toBeUndefined();
+  });
+
+  test('update event does not set apns-collapse-id so every update is delivered', () => {
+    const req = createLiveActivityRequest({
+      data: { event: 'update', activity_id: 'laundry-001' },
+    });
+    const { payload } = legacy.createPayload(req);
+    expect(payload.apns.headers['apns-collapse-id']).toBeUndefined();
+  });
+
+  test('end event does not set apns-collapse-id so the dismissal is delivered', () => {
+    const req = createLiveActivityRequest({ data: { event: 'end', activity_id: 'laundry-001' } });
+    const { payload } = legacy.createPayload(req);
+    expect(payload.apns.headers['apns-collapse-id']).toBeUndefined();
+  });
+
   test('url in data is forwarded into content-state for tap navigation', () => {
     const req = createMockRequest({
       body: {


### PR DESCRIPTION
## Summary

When a device is offline, APNs only stores the most recent notification per device token. Because every Live Activity push for a given app shares the same push-to-start token, multiple distinct start pushes queued while offline clobber each other, and there is nothing tying queued duplicates of the *same* activity together — so behaviour is undefined and a user can end up with duplicate Live Activities once the device reconnects.

This sets `apns-collapse-id` on **start** events, keyed off the activity id (falling back to `tag`). APNs collapses queued pushes that share a collapse id into a single delivery, so:

- Multiple queued starts for the *same* activity coalesce into one → the user gets a single Live Activity instead of duplicates.
- Starts for *different* activities use different collapse ids, so each survives the offline queue instead of clobbering one another.

`update` and `end` events are intentionally left without a collapse id, so every update is delivered (the activity always reflects its latest state) and the dismissal is never dropped.

The app-side `LiveActivityRegistry` already de-duplicates by `tag` on delivery; this change reduces the redundant deliveries before they ever reach the device.