### PR TITLE
Stamp started_at on Live Activity push-to-start

### DIFF
--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -56,6 +56,10 @@ function createPayload(req) {
     aps.attributes = {
       tag: data.activity_id ?? data.tag ?? '',
       title: req.body.title ?? '',
+      // Server send-time (epoch seconds). When Core re-sends a push-to-start before it has the
+      // activity's push token, two activities can briefly exist for one tag; the app keeps the one
+      // with the largest started_at and dismisses the rest, collapsing duplicates to the newest.
+      started_at: now,
     };
     // Server that started the activity, so a tap can open the originating server when the
     // user has several. Only sent when present; the iOS attribute is optional for compatibility.

--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -56,9 +56,6 @@ function createPayload(req) {
     aps.attributes = {
       tag: data.activity_id ?? data.tag ?? '',
       title: req.body.title ?? '',
-      // Server send-time (epoch seconds). When Core re-sends a push-to-start before it has the
-      // activity's push token, two activities can briefly exist for one tag; the app keeps the one
-      // with the largest started_at and dismisses the rest, collapsing duplicates to the newest.
       started_at: now,
     };
     // Server that started the activity, so a tap can open the originating server when the

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -278,7 +278,7 @@ describe('live-activity createPayload via FCM', () => {
 
   test('update and end events do not carry started_at (it is a start-only attribute)', () => {
     for (const event of ['update', 'end']) {
-      const req = createLiveActivityRequest({ data: { event, activity_id: 'laundry-001' } });
+      const req = createLiveActivityRequest({ data: { event, tag: 'laundry-001' } });
       const { payload } = legacy.createPayload(req);
       expect(payload.apns.payload.aps.attributes).toBeUndefined();
     }

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -264,7 +264,7 @@ describe('live-activity createPayload via FCM', () => {
           live_activity_token: LIVE_ACTIVITY_TOKEN,
           title: 'Laundry',
           registration_info: { app_id: 'io.robbie.HomeAssistant' },
-          data: { event: 'start', activity_id: 'laundry-001' },
+          data: { event: 'start', tag: 'laundry-001' },
         },
       });
       const { payload } = legacy.createPayload(req);

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -247,7 +247,40 @@ describe('live-activity createPayload via FCM', () => {
     });
     const { payload } = legacy.createPayload(req);
     expect(payload.apns.payload.aps['attributes-type']).toBe('HALiveActivityAttributes');
-    expect(payload.apns.payload.aps.attributes).toEqual({ tag: 'laundry-001', title: 'Laundry' });
+    expect(payload.apns.payload.aps.attributes).toEqual({
+      tag: 'laundry-001',
+      title: 'Laundry',
+      started_at: expect.any(Number),
+    });
+  });
+
+  test('start event stamps started_at with the server send-time in epoch seconds', () => {
+    const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(1704067200000);
+
+    const req = createMockRequest({
+      body: {
+        push_token: FCM_TOKEN,
+        live_activity_token: LIVE_ACTIVITY_TOKEN,
+        title: 'Laundry',
+        registration_info: { app_id: 'io.robbie.HomeAssistant' },
+        data: { event: 'start', activity_id: 'laundry-001' },
+      },
+    });
+    const { payload } = legacy.createPayload(req);
+    const aps = payload.apns.payload.aps;
+    // The app keeps the duplicate with the largest started_at, so it must equal the send-time.
+    expect(aps.attributes.started_at).toBe(1704067200);
+    expect(aps.attributes.started_at).toBe(aps.timestamp);
+
+    dateNowSpy.mockRestore();
+  });
+
+  test('update and end events do not carry started_at (it is a start-only attribute)', () => {
+    for (const event of ['update', 'end']) {
+      const req = createLiveActivityRequest({ data: { event, activity_id: 'laundry-001' } });
+      const { payload } = legacy.createPayload(req);
+      expect(payload.apns.payload.aps.attributes).toBeUndefined();
+    }
   });
 
   test('start event includes webhook_id in attributes when registration_info has one', () => {
@@ -265,6 +298,7 @@ describe('live-activity createPayload via FCM', () => {
       tag: 'laundry-001',
       title: 'Laundry',
       webhook_id: 'wh-123',
+      started_at: expect.any(Number),
     });
   });
 

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -257,22 +257,23 @@ describe('live-activity createPayload via FCM', () => {
   test('start event stamps started_at with the server send-time in epoch seconds', () => {
     const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(1704067200000);
 
-    const req = createMockRequest({
-      body: {
-        push_token: FCM_TOKEN,
-        live_activity_token: LIVE_ACTIVITY_TOKEN,
-        title: 'Laundry',
-        registration_info: { app_id: 'io.robbie.HomeAssistant' },
-        data: { event: 'start', activity_id: 'laundry-001' },
-      },
-    });
-    const { payload } = legacy.createPayload(req);
-    const aps = payload.apns.payload.aps;
-    // The app keeps the duplicate with the largest started_at, so it must equal the send-time.
-    expect(aps.attributes.started_at).toBe(1704067200);
-    expect(aps.attributes.started_at).toBe(aps.timestamp);
-
-    dateNowSpy.mockRestore();
+    try {
+      const req = createMockRequest({
+        body: {
+          push_token: FCM_TOKEN,
+          live_activity_token: LIVE_ACTIVITY_TOKEN,
+          title: 'Laundry',
+          registration_info: { app_id: 'io.robbie.HomeAssistant' },
+          data: { event: 'start', activity_id: 'laundry-001' },
+        },
+      });
+      const { payload } = legacy.createPayload(req);
+      const aps = payload.apns.payload.aps;
+      expect(aps.attributes.started_at).toBe(1704067200);
+      expect(aps.attributes.started_at).toBe(aps.timestamp);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 
   test('update and end events do not carry started_at (it is a start-only attribute)', () => {


### PR DESCRIPTION
Adds `started_at` (epoch seconds) to the Live Activity push-to-start `attributes`.

When Home Assistant re-sends a push-to-start before it has the activity's push token, two activities can briefly exist for the same tag. With `started_at`, the iOS app keeps the most recently started one and dismisses the rest, so duplicates collapse to the newest deterministically (ActivityKit gives the device no creation order on its own).

Start-only and backward-compatible — older apps ignore the field.