### PR TITLE
Send silent Live Activity updates at apns-priority 5

### DIFF
--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -116,9 +116,11 @@ function createPayload(req) {
     );
   }
 
+  // Silent updates are non-urgent, so let APNs deliver them at a power-conserving priority. Starts
+  // and ends always go out at the immediate priority so the activity appears and dismisses promptly.
+  const isSilentUpdate = event === LiveActivityEvent.UPDATE && data.silent === true;
   const headers = {
-    // Silent updates are non-urgent, so let APNs deliver them at a power-conserving priority.
-    'apns-priority': data.silent === true ? APNS_PRIORITY_LOW : APNS_PRIORITY_IMMEDIATE,
+    'apns-priority': isSilentUpdate ? APNS_PRIORITY_LOW : APNS_PRIORITY_IMMEDIATE,
   };
 
   // Coalesce duplicate start pushes for the same activity. If several starts for the same

--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -24,6 +24,9 @@ const ATTRIBUTES_TYPE = 'HALiveActivityAttributes';
 // priority); it is a string because APNs transmits header values as strings.
 const APNS_PRIORITY_IMMEDIATE = '10';
 
+// Power-conserving priority used for silent (non-urgent) updates; APNs may delay or coalesce them.
+const APNS_PRIORITY_LOW = '5';
+
 // FCM analytics label used to identify Live Activity pushes in Firebase reporting.
 const ANALYTICS_LABEL = 'iOSLiveActivityV1';
 
@@ -114,7 +117,8 @@ function createPayload(req) {
   }
 
   const headers = {
-    'apns-priority': APNS_PRIORITY_IMMEDIATE,
+    // Silent updates are non-urgent, so let APNs deliver them at a power-conserving priority.
+    'apns-priority': data.silent === true ? APNS_PRIORITY_LOW : APNS_PRIORITY_IMMEDIATE,
   };
 
   // Coalesce duplicate start pushes for the same activity. If several starts for the same

--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -24,7 +24,7 @@ const ATTRIBUTES_TYPE = 'HALiveActivityAttributes';
 // priority); it is a string because APNs transmits header values as strings.
 const APNS_PRIORITY_IMMEDIATE = '10';
 
-// Power-conserving priority used for silent (non-urgent) updates; APNs may delay or coalesce them.
+// Power-conserving priority used for silent (non-urgent) updates; APNs may delay or coalesce them. (https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Determine-the-update-frequency)
 const APNS_PRIORITY_LOW = '5';
 
 // FCM analytics label used to identify Live Activity pushes in Firebase reporting.

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -660,7 +660,7 @@ describe('live-activity createPayload via FCM', () => {
     expect(payload.apns.headers['apns-priority']).toBe('10');
   });
 
-  test('apns-priority header is 5 when silent is true', () => {
+  test('apns-priority header is 5 for a silent update', () => {
     const req = createMockRequest({
       body: {
         push_token: FCM_TOKEN,
@@ -672,6 +672,22 @@ describe('live-activity createPayload via FCM', () => {
     });
     const { payload } = legacy.createPayload(req);
     expect(payload.apns.headers['apns-priority']).toBe('5');
+  });
+
+  test('apns-priority stays 10 for silent start and end events', () => {
+    for (const event of ['start', 'end']) {
+      const req = createMockRequest({
+        body: {
+          push_token: FCM_TOKEN,
+          live_activity_token: LIVE_ACTIVITY_TOKEN,
+          title: 'Laundry',
+          registration_info: { app_id: 'io.robbie.HomeAssistant' },
+          data: { event, tag: 'laundry-001', silent: true },
+        },
+      });
+      const { payload } = legacy.createPayload(req);
+      expect(payload.apns.headers['apns-priority']).toBe('10');
+    }
   });
 
   test('no apns-push-type or apns-topic headers (FCM sets them)', () => {

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -660,6 +660,20 @@ describe('live-activity createPayload via FCM', () => {
     expect(payload.apns.headers['apns-priority']).toBe('10');
   });
 
+  test('apns-priority header is 5 when silent is true', () => {
+    const req = createMockRequest({
+      body: {
+        push_token: FCM_TOKEN,
+        live_activity_token: LIVE_ACTIVITY_TOKEN,
+        title: 'Laundry',
+        registration_info: { app_id: 'io.robbie.HomeAssistant' },
+        data: { event: 'update', tag: 'laundry-001', silent: true },
+      },
+    });
+    const { payload } = legacy.createPayload(req);
+    expect(payload.apns.headers['apns-priority']).toBe('5');
+  });
+
   test('no apns-push-type or apns-topic headers (FCM sets them)', () => {
     const req = createLiveActivityRequest();
     const { payload } = legacy.createPayload(req);


### PR DESCRIPTION
When `silent: true` is set, deliver the Live Activity push at `apns-priority: 5` (power-conserving) instead of `10` (immediate).

Silent updates are non-urgent — they intentionally suppress the alert/chime — so the lower priority lets APNs batch or delay delivery to save battery, which is the recommended priority for non-urgent Live Activity updates. Everything else still goes out at priority 10.