### PR TITLE
Always set mutable-content on legacy alert pushes, except silent pushes

### DIFF
--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -117,7 +117,6 @@ module.exports = {
         updateRateLimits = false;
       } else {
         let needsCategory = false;
-        let needsMutableContent = false;
 
         if (req.body.data) {
           if (req.body.data.subtitle) {
@@ -159,7 +158,6 @@ module.exports = {
           if (req.body.data.entity_id) {
             payload.apns.payload.entity_id = req.body.data.entity_id;
             needsCategory = true;
-            needsMutableContent = true;
           }
 
           if (req.body.data.level !== undefined) {
@@ -180,7 +178,6 @@ module.exports = {
           if (req.body.data.attachment) {
             payload.apns.payload.attachment = req.body.data.attachment;
             needsCategory = true;
-            needsMutableContent = true;
           }
 
           const addAttachment = (url, contentType) => {
@@ -201,7 +198,6 @@ module.exports = {
             }
 
             needsCategory = true;
-            needsMutableContent = true;
           };
 
           addAttachment(req.body.data.video, 'mpeg4');
@@ -239,7 +235,7 @@ module.exports = {
           payload.apns.payload.aps.category = payload.apns.payload.aps.category.toUpperCase();
         }
 
-        if (needsMutableContent) {
+        if (!payload.apns.payload.aps.contentAvailable) {
           payload.apns.payload.aps.mutableContent = true;
         }
 

--- a/functions/test/fixtures/legacy/action_data.json
+++ b/functions/test/fixtures/legacy/action_data.json
@@ -24,6 +24,7 @@
         "body": "test"
       },
       "category": "DYNAMIC",
+      "mutableContent": true,
       "sound": "default"
     },
     "homeassistant": {

--- a/functions/test/fixtures/legacy/actions.json
+++ b/functions/test/fixtures/legacy/actions.json
@@ -25,6 +25,7 @@
         "body": "test"
       },
       "category": "DYNAMIC",
+      "mutableContent": true,
       "sound": "default"
     },
     "actions": [

--- a/functions/test/fixtures/legacy/actions_and_category.json
+++ b/functions/test/fixtures/legacy/actions_and_category.json
@@ -28,6 +28,7 @@
         "body": "test"
       },
       "category": "CUSTOM_CATEGORY",
+      "mutableContent": true,
       "sound": "default"
     },
     "actions": [

--- a/functions/test/fixtures/legacy/badge.json
+++ b/functions/test/fixtures/legacy/badge.json
@@ -22,6 +22,7 @@
         "body": "test"
       },
       "badge": 3,
+      "mutableContent": true,
       "sound": "default"
     }
   }

--- a/functions/test/fixtures/legacy/category.json
+++ b/functions/test/fixtures/legacy/category.json
@@ -22,6 +22,7 @@
         "body": "test"
       },
       "category": "CUSTOM_CATEGORY",
+      "mutableContent": true,
       "sound": "default"
     }
   }

--- a/functions/test/fixtures/legacy/category_lowercase.json
+++ b/functions/test/fixtures/legacy/category_lowercase.json
@@ -22,6 +22,7 @@
         "body": "test"
       },
       "category": "CUSTOM_CATEGORY",
+      "mutableContent": true,
       "sound": "default"
     }
   }

--- a/functions/test/fixtures/legacy/command_test_push_source.json
+++ b/functions/test/fixtures/legacy/command_test_push_source.json
@@ -17,6 +17,7 @@
         "title": "test_push_source",
         "body": "apns-fcm"
       },
+      "mutableContent": true,
       "sound": "default"
     }
   }

--- a/functions/test/fixtures/legacy/delete_alert.json
+++ b/functions/test/fixtures/legacy/delete_alert.json
@@ -19,7 +19,8 @@
   "payload": {
     "aps": {
       "alert": {},
-      "badge": 3
+      "badge": 3,
+      "mutableContent": true
     }
   }
 }

--- a/functions/test/fixtures/legacy/group.json
+++ b/functions/test/fixtures/legacy/group.json
@@ -19,6 +19,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "default",
       "thread-id": "test_group"
     }

--- a/functions/test/fixtures/legacy/group_using_old_field.json
+++ b/functions/test/fixtures/legacy/group_using_old_field.json
@@ -21,6 +21,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "default",
       "thread-id": "test_group"
     }

--- a/functions/test/fixtures/legacy/kiosk_set_brightness.json
+++ b/functions/test/fixtures/legacy/kiosk_set_brightness.json
@@ -19,6 +19,7 @@
       "alert": {
         "body": "kiosk_set_brightness"
       },
+      "mutableContent": true,
       "sound": "default"
     },
     "level": 50

--- a/functions/test/fixtures/legacy/kiosk_set_volume.json
+++ b/functions/test/fixtures/legacy/kiosk_set_volume.json
@@ -19,6 +19,7 @@
       "alert": {
         "body": "kiosk_set_volume"
       },
+      "mutableContent": true,
       "sound": "default"
     },
     "volume": 100

--- a/functions/test/fixtures/legacy/plain.json
+++ b/functions/test/fixtures/legacy/plain.json
@@ -16,6 +16,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "default"
     }
   }

--- a/functions/test/fixtures/legacy/presentation_options.json
+++ b/functions/test/fixtures/legacy/presentation_options.json
@@ -19,6 +19,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "default"
     },
     "presentation_options": ["alert", "badge", "sound"]

--- a/functions/test/fixtures/legacy/registration_info_webhook_id.json
+++ b/functions/test/fixtures/legacy/registration_info_webhook_id.json
@@ -17,6 +17,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "default"
     },
     "webhook_id": "webhook_id_123"

--- a/functions/test/fixtures/legacy/shortcut.json
+++ b/functions/test/fixtures/legacy/shortcut.json
@@ -22,6 +22,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "default"
     },
     "shortcut": {

--- a/functions/test/fixtures/legacy/sound_critical_iOS.json
+++ b/functions/test/fixtures/legacy/sound_critical_iOS.json
@@ -25,6 +25,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": {
         "critical": 1,
         "name": "custom.wav",

--- a/functions/test/fixtures/legacy/sound_critical_macOS-10.15.json
+++ b/functions/test/fixtures/legacy/sound_critical_macOS-10.15.json
@@ -25,6 +25,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": {
         "critical": 1,
         "name": "custom",

--- a/functions/test/fixtures/legacy/sound_critical_macOS-11.json
+++ b/functions/test/fixtures/legacy/sound_critical_macOS-11.json
@@ -25,6 +25,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": {
         "critical": 1,
         "name": "custom.wav",

--- a/functions/test/fixtures/legacy/sound_critical_no_volume.json
+++ b/functions/test/fixtures/legacy/sound_critical_no_volume.json
@@ -25,6 +25,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": {
         "critical": 1,
         "name": "default",

--- a/functions/test/fixtures/legacy/sound_none.json
+++ b/functions/test/fixtures/legacy/sound_none.json
@@ -20,7 +20,8 @@
     "aps": {
       "alert": {
         "body": "test"
-      }
+      },
+      "mutableContent": true
     }
   }
 }

--- a/functions/test/fixtures/legacy/sound_not_in_push.json
+++ b/functions/test/fixtures/legacy/sound_not_in_push.json
@@ -19,6 +19,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "custom_sound.wav"
     }
   }

--- a/functions/test/fixtures/legacy/sound_regular_but_in_object.json
+++ b/functions/test/fixtures/legacy/sound_regular_but_in_object.json
@@ -25,6 +25,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": {
         "critical": 0,
         "name": "custom.wav",

--- a/functions/test/fixtures/legacy/sound_regular_iOS.json
+++ b/functions/test/fixtures/legacy/sound_regular_iOS.json
@@ -21,6 +21,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "custom_sound.wav"
     }
   }

--- a/functions/test/fixtures/legacy/sound_regular_macOS-10.15.json
+++ b/functions/test/fixtures/legacy/sound_regular_macOS-10.15.json
@@ -21,6 +21,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "custom_sound"
     }
   }

--- a/functions/test/fixtures/legacy/sound_regular_macOS-11.json
+++ b/functions/test/fixtures/legacy/sound_regular_macOS-11.json
@@ -21,6 +21,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "custom_sound.wav"
     }
   }

--- a/functions/test/fixtures/legacy/tag.json
+++ b/functions/test/fixtures/legacy/tag.json
@@ -20,6 +20,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "default"
     }
   }

--- a/functions/test/fixtures/legacy/tag_and_group.json
+++ b/functions/test/fixtures/legacy/tag_and_group.json
@@ -21,6 +21,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "default",
       "thread-id": "test_group"
     }

--- a/functions/test/fixtures/legacy/tag_using_old_header.json
+++ b/functions/test/fixtures/legacy/tag_using_old_header.json
@@ -22,6 +22,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "default"
     }
   }

--- a/functions/test/fixtures/legacy/url.json
+++ b/functions/test/fixtures/legacy/url.json
@@ -19,6 +19,7 @@
       "alert": {
         "body": "test"
       },
+      "mutableContent": true,
       "sound": "default"
     },
     "url": "/url.html"

--- a/functions/test/fixtures/legacy/with_titles.json
+++ b/functions/test/fixtures/legacy/with_titles.json
@@ -22,6 +22,7 @@
         "title": "title test",
         "subtitle": "subtitle test"
       },
+      "mutableContent": true,
       "sound": "default"
     }
   }


### PR DESCRIPTION
## Summary
- `legacy.js` previously only set `mutable-content` on the APNs payload when the push needed the notification service extension (attachment, `entity_id`). Now it's set on every alert push by default.
- Silent/background pushes (`content-available`) are explicitly excluded — they never carry `mutable-content`.
- Removed the now-unused `needsMutableContent` tracking variable.

Use case: iOS app will modify the notification to include default snooze options for notifications without actions provided by the user.

In practice user can snooze notifications and configure snooze time on the app itself.

iOS PR: https://github.com/home-assistant/iOS/pull/4904