### PR TITLE
Forward mode for kiosk_set_screensaver_mode command

### DIFF
--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -170,6 +170,11 @@ module.exports = {
             payload.apns.payload.volume = req.body.data.volume;
           }
 
+          if (req.body.data.mode !== undefined) {
+            // Kiosk command value for kiosk_set_screensaver_mode
+            payload.apns.payload.mode = req.body.data.mode;
+          }
+
           if (req.body.data.action_data) {
             payload.apns.payload.homeassistant = req.body.data.action_data;
             needsCategory = true;

--- a/functions/test/fixtures/legacy/kiosk_set_screensaver_brightness.json
+++ b/functions/test/fixtures/legacy/kiosk_set_screensaver_brightness.json
@@ -1,0 +1,27 @@
+{
+  "input": {
+    "message": "kiosk_set_screensaver_brightness",
+    "data": {
+      "level": 20
+    },
+    "registration_info": {
+      "app_id": "io.robbie.HomeAssistant.dev",
+      "os_version": "10.15",
+      "app_version": "2021.5"
+    }
+  },
+  "rate_limit": true,
+  "headers": {
+    "apns-push-type": "alert"
+  },
+  "payload": {
+    "aps": {
+      "alert": {
+        "body": "kiosk_set_screensaver_brightness"
+      },
+      "mutableContent": true,
+      "sound": "default"
+    },
+    "level": 20
+  }
+}

--- a/functions/test/fixtures/legacy/kiosk_set_screensaver_mode.json
+++ b/functions/test/fixtures/legacy/kiosk_set_screensaver_mode.json
@@ -1,0 +1,27 @@
+{
+  "input": {
+    "message": "kiosk_set_screensaver_mode",
+    "data": {
+      "mode": "dim"
+    },
+    "registration_info": {
+      "app_id": "io.robbie.HomeAssistant.dev",
+      "os_version": "10.15",
+      "app_version": "2021.5"
+    }
+  },
+  "rate_limit": true,
+  "headers": {
+    "apns-push-type": "alert"
+  },
+  "payload": {
+    "aps": {
+      "alert": {
+        "body": "kiosk_set_screensaver_mode"
+      },
+      "mutableContent": true,
+      "sound": "default"
+    },
+    "mode": "dim"
+  }
+}


### PR DESCRIPTION
## Summary

Forwards the `mode` field from the notification payload into the APNs payload, so the iOS Companion app can act on the new `kiosk_set_screensaver_mode` remote command. This mirrors the existing `level`/`volume` forwarding added for `kiosk_set_brightness`/`kiosk_set_volume`.

- `functions/legacy.js`: forward `req.body.data.mode` → `payload.apns.payload.mode` when present.
- `kiosk_set_screensaver_brightness` reuses the already-forwarded `level` field, so no code change is needed for it; a fixture is added to lock that in.

### Example notification data

```yaml
- action: notify.mobile_app_<device>
  data:
    message: "kiosk_set_screensaver_mode"
    data:
      mode: "dim"
- action: notify.mobile_app_<device>
  data:
    message: "kiosk_set_screensaver_brightness"
    data:
      level: 20
```

## Related

- iOS app: home-assistant/iOS#5069 (adds the commands)
- Docs: companion.home-assistant PR (documents both commands)

Opened as a draft pending the iOS app change (#5069) landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)