### PR TITLE
Forward progress_bar_direction in Live Activity content-state

### DIFF
--- a/functions/live-activity.js
+++ b/functions/live-activity.js
@@ -186,6 +186,8 @@ function buildContentState(body, data) {
   if (data.background_color !== undefined) state.background_color = data.background_color;
   if (data.text_color !== undefined) state.text_color = data.text_color;
   if (data.progress_bar_color !== undefined) state.progress_bar_color = data.progress_bar_color;
+  if (data.progress_bar_direction !== undefined)
+    state.progress_bar_direction = data.progress_bar_direction;
   if (data.url !== undefined) state.url = data.url;
   if (data.when !== undefined) {
     state.countdown_end = data.when_relative
@@ -207,6 +209,8 @@ function buildContentState(body, data) {
     if (cs.background_color !== undefined) state.background_color = cs.background_color;
     if (cs.text_color !== undefined) state.text_color = cs.text_color;
     if (cs.progress_bar_color !== undefined) state.progress_bar_color = cs.progress_bar_color;
+    if (cs.progress_bar_direction !== undefined)
+      state.progress_bar_direction = cs.progress_bar_direction;
     if (cs.url !== undefined) state.url = cs.url;
   }
 

--- a/functions/test/fixtures/live-activity/update-full.json
+++ b/functions/test/fixtures/live-activity/update-full.json
@@ -19,6 +19,7 @@
       "when": 1704110400,
       "notification_icon": "mdi:timer",
       "notification_icon_color": "#FF5722",
+      "progress_bar_direction": "decreasing",
       "stale_date": 1234571490,
       "relevance_score": 0.8,
       "alert": {
@@ -41,7 +42,8 @@
       "chronometer": true,
       "countdown_end": 1704110400,
       "icon": "mdi:timer",
-      "color": "#FF5722"
+      "color": "#FF5722",
+      "progress_bar_direction": "decreasing"
     },
     "staleDate": 1234571490,
     "relevanceScore": 0.8,

--- a/functions/test/legacy.test.js
+++ b/functions/test/legacy.test.js
@@ -484,6 +484,7 @@ describe('live-activity createPayload via FCM', () => {
             countdown_end: 1704067200,
             icon: 'mdi:test',
             color: '#FF0000',
+            progress_bar_direction: 'decreasing',
           },
         },
       },
@@ -499,6 +500,7 @@ describe('live-activity createPayload via FCM', () => {
     expect(cs.countdown_end).toBe(1704067200);
     expect(cs.icon).toBe('mdi:test');
     expect(cs.color).toBe('#FF0000');
+    expect(cs.progress_bar_direction).toBe('decreasing');
   });
 
   test('flat Live Activity fields are translated into content-state', () => {
@@ -520,6 +522,7 @@ describe('live-activity createPayload via FCM', () => {
           background_color: '#101820',
           text_color: '#FFFFFF',
           progress_bar_color: '#FF9800',
+          progress_bar_direction: 'decreasing',
         },
       },
     });
@@ -536,6 +539,7 @@ describe('live-activity createPayload via FCM', () => {
       background_color: '#101820',
       text_color: '#FFFFFF',
       progress_bar_color: '#FF9800',
+      progress_bar_direction: 'decreasing',
     });
   });
 


### PR DESCRIPTION
Forwards the new optional `progress_bar_direction` field (`increasing`/`decreasing`) to the Live Activity content-state, from both the flat data fields and the explicit `content_state` object. Without this the field is stripped by the content-state whitelist and never reaches the device over remote push.

Companion to home-assistant/iOS#5180.