### PR TITLE
Forward notification icon fields in legacy APNS payload

### DIFF
--- a/functions/legacy.js
+++ b/functions/legacy.js
@@ -221,6 +221,13 @@ module.exports = {
             payload.apns.payload.presentation_options = req.body.data.presentation_options;
           }
 
+          // Communication / custom-icon fields
+          for (const key of ['notification_icon', 'icon_url', 'notification_icon_color', 'color']) {
+            if (req.body.data[key] !== undefined) {
+              payload.apns.payload[key] = req.body.data[key];
+            }
+          }
+
           if (typeof req.body.data.tag === 'string') {
             payload.apns.headers['apns-collapse-id'] = req.body.data.tag;
           }

--- a/functions/test/fixtures/legacy/notification_icon.json
+++ b/functions/test/fixtures/legacy/notification_icon.json
@@ -1,0 +1,33 @@
+{
+  "input": {
+    "message": "test",
+    "data": {
+      "notification_icon": "mdi:cellphone",
+      "icon_url": "https://example.com/avatar.png",
+      "notification_icon_color": "#FFFFFF",
+      "color": "#03A9F4"
+    },
+    "registration_info": {
+      "app_id": "io.robbie.HomeAssistant.dev",
+      "os_version": "17.0",
+      "app_version": "2024.1"
+    }
+  },
+  "rate_limit": true,
+  "headers": {
+    "apns-push-type": "alert"
+  },
+  "payload": {
+    "aps": {
+      "alert": {
+        "body": "test"
+      },
+      "mutableContent": true,
+      "sound": "default"
+    },
+    "notification_icon": "mdi:cellphone",
+    "icon_url": "https://example.com/avatar.png",
+    "notification_icon_color": "#FFFFFF",
+    "color": "#03A9F4"
+  }
+}


### PR DESCRIPTION
Copies `notification_icon`, `icon_url`, `notification_icon_color` and `color` from the notification data into the top-level APNS payload, so the iOS Notification Service Extension can read them on cloud pushes.

Adds a fixture-driven test covering the new fields.