### PR TITLE
Now playing direct apns

### DIFF
--- a/functions/apns-provider.js
+++ b/functions/apns-provider.js
@@ -1,0 +1,197 @@
+'use strict';
+
+const http2 = require('node:http2');
+const crypto = require('node:crypto');
+
+// Apple's provider API hosts. Which one a token belongs to is a property of the build that
+// created it, so this is configuration rather than something the relay can infer.
+const APNS_HOST_PRODUCTION = 'https://api.push.apple.com';
+const APNS_HOST_SANDBOX = 'https://api.sandbox.push.apple.com';
+
+// Apple rejects a provider token older than one hour. Refreshing well inside that leaves room
+// for clock skew and for a request that is already in flight when the token ages out.
+const PROVIDER_TOKEN_LIFETIME_SECONDS = 45 * 60;
+
+// A request that has not been answered in this long is treated as a connection problem rather
+// than left to hang: Home Assistant is waiting on the other end of this.
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Minimal token-authenticated APNs provider over HTTP/2.
+ *
+ * It exists because Firebase Admin has no field for a Now Playing session token the way it has
+ * `apns.liveActivityToken` for Live Activities, so this one delivery path cannot go through FCM.
+ * Deliberately small: one connection, one signing key, no retry policy, no payload knowledge.
+ *
+ * Nothing here logs. The signing key, the provider JWT and the destination token only ever
+ * leave this object as an HTTP/2 header, and the caller decides what to record.
+ */
+class ApnsProvider {
+  /**
+   * @param {object} options
+   * @param {string} options.key PEM-encoded P-256 private key (an Apple `.p8`).
+   * @param {string} options.keyId Apple's identifier for that key.
+   * @param {string} options.teamId Apple Developer team identifier.
+   * @param {boolean} [options.production] Production host when true, sandbox when false.
+   * @param {() => number} [options.now] Injectable clock, in milliseconds.
+   * @param {(host: string) => import('node:http2').ClientHttp2Session} [options.connect]
+   *   Injectable connector, so tests never reach Apple.
+   */
+  constructor({ key, keyId, teamId, production = true, now, connect }) {
+    if (!key || !keyId || !teamId) {
+      throw new Error('ApnsProvider requires key, keyId and teamId');
+    }
+    this.keyId = keyId;
+    this.teamId = teamId;
+    this.host = production ? APNS_HOST_PRODUCTION : APNS_HOST_SANDBOX;
+    this.now = now || (() => Date.now());
+    this.connect = connect || ((host) => http2.connect(host));
+    this.signingKey = crypto.createPrivateKey(key);
+    /** @type {import('node:http2').ClientHttp2Session | null} */
+    this.session = null;
+    /** @type {{ value: string, expiresAt: number } | null} */
+    this.providerToken = null;
+  }
+
+  /**
+   * The cached provider JWT, signed afresh only once it is close to Apple's one-hour maximum.
+   *
+   * A Now Playing session can update on every track change, and signing per request would burn
+   * CPU on a value that stays valid for the better part of an hour.
+   *
+   * @returns {string}
+   */
+  authorizationToken() {
+    const nowSeconds = Math.floor(this.now() / 1000);
+    if (this.providerToken && this.providerToken.expiresAt > nowSeconds) {
+      return this.providerToken.value;
+    }
+
+    const header = base64url(JSON.stringify({ alg: 'ES256', kid: this.keyId }));
+    const claims = base64url(JSON.stringify({ iss: this.teamId, iat: nowSeconds }));
+    const signingInput = `${header}.${claims}`;
+    // APNs wants a JWS signature, meaning raw R||S rather than the DER encoding `createSign`
+    // produces.
+    const signature = crypto.sign('sha256', Buffer.from(signingInput), {
+      key: this.signingKey,
+      dsaEncoding: 'ieee-p1363',
+    });
+
+    const value = `${signingInput}.${base64url(signature)}`;
+    this.providerToken = { value, expiresAt: nowSeconds + PROVIDER_TOKEN_LIFETIME_SECONDS };
+    return value;
+  }
+
+  /**
+   * The shared HTTP/2 session, reopened when the last one is gone.
+   *
+   * Apple sends GOAWAY routinely and expects the provider to reconnect rather than to treat it
+   * as an error, so a closed or destroyed session is simply replaced on the next send.
+   *
+   * @returns {import('node:http2').ClientHttp2Session}
+   */
+  connection() {
+    if (this.session && !this.session.closed && !this.session.destroyed) {
+      return this.session;
+    }
+    const session = this.connect(this.host);
+    for (const event of ['error', 'close', 'goaway']) {
+      // The `error` listener is not optional: without one a session-level error becomes an
+      // unhandled exception and takes the process with it. The next send reconnects.
+      session.on(event, () => {
+        if (this.session === session) {
+          this.session = null;
+        }
+      });
+    }
+    this.session = session;
+    return session;
+  }
+
+  /**
+   * Sends one notification and resolves with Apple's answer, including its refusals.
+   *
+   * A rejection means the request never reached Apple. A resolution with a non-200 status means
+   * Apple answered and said no, which is a different thing and is classified by the caller.
+   *
+   * @param {object} request
+   * @param {string} request.token Destination device token, lowercase hex.
+   * @param {string} request.topic Value for `apns-topic`.
+   * @param {string} request.pushType Value for `apns-push-type`.
+   * @param {Buffer} request.body Encoded JSON payload.
+   * @returns {Promise<{ status: number, apnsId: string | null, reason: string | null }>}
+   */
+  async send({ token, topic, pushType, body }) {
+    let stream;
+    try {
+      stream = this.connection().request({
+        ':method': 'POST',
+        ':path': `/3/device/${token}`,
+        authorization: `bearer ${this.authorizationToken()}`,
+        'apns-topic': topic,
+        'apns-push-type': pushType,
+        'content-type': 'application/json',
+        'content-length': body.length,
+      });
+    } catch (err) {
+      // The session was unusable and said so synchronously. Drop it so the next send reconnects.
+      this.session = null;
+      throw err;
+    }
+
+    return new Promise((resolve, reject) => {
+      let status = 0;
+      let apnsId = null;
+      const chunks = [];
+
+      // Whichever of these settles first wins; a promise ignores the rest.
+      stream.setTimeout(REQUEST_TIMEOUT_MS, () => {
+        stream.close(http2.constants.NGHTTP2_CANCEL);
+        reject(new Error('APNs request timed out'));
+      });
+      stream.on('error', reject);
+
+      stream.on('response', (headers) => {
+        status = Number(headers[':status']) || 0;
+        const id = headers['apns-id'];
+        apnsId = typeof id === 'string' ? id : null;
+      });
+      stream.on('data', (chunk) => chunks.push(chunk));
+      stream.on('end', () => {
+        resolve({ status, apnsId, reason: parseReason(Buffer.concat(chunks)) });
+      });
+
+      stream.end(body);
+    });
+  }
+
+  /** Closes the shared connection. Used by tests and by orderly shutdown. */
+  close() {
+    if (this.session && !this.session.closed && !this.session.destroyed) {
+      this.session.close();
+    }
+    this.session = null;
+  }
+}
+
+/** @param {Buffer} buffer */
+function parseReason(buffer) {
+  if (!buffer.length) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(buffer.toString('utf8'));
+    return typeof parsed.reason === 'string' ? parsed.reason : null;
+  } catch {
+    // Apple answered with something that is not the documented JSON body. The status code is
+    // still meaningful, and the body may contain anything, so it is not propagated.
+    return null;
+  }
+}
+
+/** @param {string | Buffer} value */
+function base64url(value) {
+  return Buffer.from(value).toString('base64url');
+}
+
+module.exports = { ApnsProvider };

--- a/functions/handlers.js
+++ b/functions/handlers.js
@@ -3,8 +3,25 @@
 const { Logging } = require('@google-cloud/logging');
 const { getMessaging } = require('firebase-admin/messaging');
 const { FirestoreRateLimiter, ValkeyRateLimiter } = require('./rate-limiter');
+const { NOW_PLAYING_DESTINATION_PREFIX, NOW_PLAYING_KEY_PREFIX } = require('./rate-limiter/util');
+const {
+  isNowPlayingRequest,
+  prepareNowPlaying,
+  classifyApnsResponse,
+  destinationIdentity,
+  nowPlayingProvider,
+  tokenFingerprint,
+} = require('./now-playing');
 
 const MAX_NOTIFICATIONS_PER_DAY = parseInt(process.env.MAX_NOTIFICATIONS_PER_DAY || '500');
+
+// Remote Now Playing gets its own daily ceiling, deliberately far above the notification quota:
+// this traffic is machine-generated state synchronization, and a heavy listening day of track,
+// transport and volume changes lands in the low hundreds. 5000 stays an order of magnitude clear
+// of real use while still bounding a runaway client to roughly three pushes a minute sustained.
+const MAX_NOW_PLAYING_UPDATES_PER_DAY = parseInt(
+  process.env.MAX_NOW_PLAYING_UPDATES_PER_DAY || '5000',
+);
 const REGION = (process.env.REGION || 'us-central1').toLowerCase();
 
 const usingCloudFunctions = process.env.FUNCTION_TARGET !== undefined;
@@ -16,6 +33,8 @@ const debug = process.env.DEBUG === 'true';
 // Use Valkey rate limiter if Valkey config is available, otherwise use Firestore
 let rateLimiter;
 const useValkey = process.env.VALKEY_HOST && process.env.VALKEY_PORT;
+// Metered separately from notifications, in the same backend and under the same day partition.
+let nowPlayingRateLimiter;
 if (useValkey) {
   rateLimiter = new ValkeyRateLimiter(
     MAX_NOTIFICATIONS_PER_DAY,
@@ -23,8 +42,20 @@ if (useValkey) {
     process.env.VALKEY_HOST,
     parseInt(process.env.VALKEY_PORT, 10),
   );
+  nowPlayingRateLimiter = new ValkeyRateLimiter(
+    MAX_NOW_PLAYING_UPDATES_PER_DAY,
+    debug,
+    process.env.VALKEY_HOST,
+    parseInt(process.env.VALKEY_PORT, 10),
+    NOW_PLAYING_KEY_PREFIX,
+  );
 } else {
   rateLimiter = new FirestoreRateLimiter(MAX_NOTIFICATIONS_PER_DAY, debug);
+  nowPlayingRateLimiter = new FirestoreRateLimiter(
+    MAX_NOW_PLAYING_UPDATES_PER_DAY,
+    debug,
+    NOW_PLAYING_KEY_PREFIX,
+  );
 }
 
 async function handleCheckRateLimits(req, res) {
@@ -62,6 +93,14 @@ async function handleRequest(req, res, payloadHandler) {
   if (token.indexOf(':') === -1) {
     // A check for old SNS tokens
     return res.status(403).send({ errorMessage: 'That is not a valid FCM token' });
+  }
+
+  // Apple's Now Playing sessions cannot be addressed through FCM. Firebase Admin has no field
+  // for their per-session token the way it has `liveActivityToken`, so that one delivery path
+  // goes straight to APNs from here. Everything before this point is shared, including the FCM
+  // token check, so the rate-limit identity stays the same for both.
+  if (isNowPlayingRequest(req.body)) {
+    return handleNowPlayingRequest(req, res, token);
   }
 
   const { updateRateLimits, payload } = payloadHandler(req);
@@ -149,6 +188,151 @@ async function handleRequest(req, res, payloadHandler) {
   });
 }
 
+/**
+ * Delivers one Now Playing `update` or `end` straight to APNs.
+ *
+ * The response is deliberately machine-readable. Home Assistant has to be able to tell a dead
+ * session token, which it should unregister, from a topic or provider-credential problem,
+ * which is ours and must never cost the user their registration.
+ *
+ * The quotas it charges are a safety ceiling rather than the mechanism that keeps this traffic
+ * reasonable, which is Home Assistant's job. A server that reaches either is pushing far more
+ * than the product needs.
+ */
+async function handleNowPlayingRequest(req, res, token) {
+  const log = logging.log('handleNowPlaying');
+  const metadata = buildLogMetadata(req);
+
+  const prepared = prepareNowPlaying(req.body);
+  if (!prepared.ok) {
+    // One step name for the whole delivery path, refusals included: Home Assistant discriminates
+    // on `errorType`, and a second step name would only give it a reason to parse two fields.
+    return res.status(prepared.status).send({ ...prepared.error, errorStep: 'sendNowPlaying' });
+  }
+
+  const provider = nowPlayingProvider();
+  if (!provider) {
+    return res.status(501).send({
+      errorType: 'NowPlayingNotConfigured',
+      errorStep: 'sendNowPlaying',
+      message: 'This deployment has no Now Playing APNs credentials configured.',
+    });
+  }
+
+  // What is safe to record. The payload is; the destination token is not.
+  const loggable = {
+    event: prepared.event,
+    topic: prepared.request.topic,
+    target: tokenFingerprint(prepared.request.token),
+    payloadBytes: prepared.request.body.length,
+  };
+
+  // Two counters, both of which have to allow the send.
+  //
+  // The registration counter is keyed on the Companion token, which is the identity every other
+  // quota in this service uses. On its own it is not enough here: unlike the Firebase path,
+  // nothing on this path ever hands that token to Firebase, so it is only ever checked for shape.
+  // A caller could invent a new one per request, be given an empty bucket each time, and push at
+  // one real device without limit. The second counter is keyed on the device the push actually
+  // reaches, so inventing registrations gains nothing.
+  const quotas = [
+    token,
+    `${NOW_PLAYING_DESTINATION_PREFIX}${destinationIdentity(prepared.request.token)}`,
+  ];
+
+  // Read both before charging either. Charging as we go would leave an attempt recorded against
+  // one counter for a request the other refused, which no success or error ever answers.
+  let allowances;
+  try {
+    allowances = await Promise.all(quotas.map((key) => nowPlayingRateLimiter.checkRateLimit(key)));
+  } catch (err) {
+    return handleError(req, res, loggable, 'getRateLimitDoc', err);
+  }
+
+  if (allowances.some((allowance) => allowance.isRateLimited)) {
+    // No visible warning push: filling this ceiling is something Home Assistant reads and backs
+    // off from, not something to tell the user about. `shouldSendRateLimitNotification` is what
+    // triggers the user-facing "Notifications Rate Limited" alert, and it is ignored here.
+    //
+    // The counters reported are the registration's, which is what `target` names. The destination
+    // counter is shared by every registration pushing at that device, and its numbers are not this
+    // caller's to read.
+    return res.status(429).send({
+      errorType: 'RateLimited',
+      message:
+        'The given target has reached the maximum number of Now Playing updates allowed per day. Please try again later.',
+      target: token,
+      rateLimits: allowances[0].rateLimits,
+    });
+  }
+
+  try {
+    await Promise.all(quotas.map((key) => nowPlayingRateLimiter.recordAttempt(key)));
+  } catch (err) {
+    return handleError(req, res, loggable, 'getRateLimitDoc', err);
+  }
+
+  if (debug) {
+    log.info(log.entry(metadata, { message: 'Sending Now Playing update', ...loggable }));
+  }
+
+  let response;
+  try {
+    response = await provider.send(prepared.request);
+  } catch (err) {
+    // The request never reached Apple: a connection or TLS failure, or a timeout.
+    await Promise.all(quotas.map((key) => nowPlayingRateLimiter.recordError(key)));
+    await reportError(err, 'sendNowPlaying', req, loggable);
+    return res.status(502).send({
+      errorType: 'ApnsUnavailable',
+      errorStep: 'sendNowPlaying',
+      message: err.message,
+    });
+  }
+
+  const outcome = classifyApnsResponse(response);
+
+  if (!outcome.ok) {
+    await Promise.all(quotas.map((key) => nowPlayingRateLimiter.recordError(key)));
+    if (debug) {
+      log.info(
+        log.entry(metadata, {
+          message: 'Now Playing delivery refused',
+          ...loggable,
+          errorType: outcome.errorType,
+          errorCode: response.reason,
+          apnsStatus: response.status,
+        }),
+      );
+    }
+    return res.status(outcome.httpStatus).send({
+      errorType: outcome.errorType,
+      errorCode: response.reason,
+      errorStep: 'sendNowPlaying',
+      apnsStatus: response.status,
+      apnsId: response.apnsId,
+      target: loggable.target,
+    });
+  }
+
+  // The registration's counters are what the response reports, and the destination's are advanced
+  // alongside them so both stay answered.
+  const [rateLimits] = await Promise.all(
+    quotas.map((key) => nowPlayingRateLimiter.recordSuccess(key)),
+  );
+
+  if (debug) {
+    log.info(log.entry(metadata, { message: 'Sent Now Playing update', ...loggable }));
+  }
+
+  return res.status(201).send({
+    messageId: response.apnsId,
+    sentPayload: JSON.parse(prepared.request.body.toString('utf8')),
+    target: loggable.target,
+    rateLimits,
+  });
+}
+
 function handleError(req, res, payload = {}, step, incomingError, shouldExit = true) {
   const log = logging.log('handleError');
   const metadata = buildLogMetadata(req);
@@ -225,13 +409,33 @@ function handleError(req, res, payload = {}, step, incomingError, shouldExit = t
   });
 }
 
+/**
+ * Strips values that must not reach Cloud Logging from a request body.
+ *
+ * Error reporting records the whole body, which is fine for an ordinary notification but not for
+ * a Now Playing destination token: it is a device-scoped identifier that can be pushed to. The
+ * body is returned unchanged, by reference, when there is nothing to redact, so this is a no-op
+ * for every existing path.
+ *
+ * @param {object} body
+ */
+function redactForLogging(body) {
+  if (!body || typeof body !== 'object' || !body.now_playing_token) {
+    return body;
+  }
+  return {
+    ...body,
+    now_playing_token: `[redacted:${tokenFingerprint(String(body.now_playing_token))}]`,
+  };
+}
+
 function reportError(err, step, req, notificationObj) {
   const logName = 'errors-' + step;
   const log = logging.log(logName);
 
   const labels = {
     step,
-    requestBody: JSON.stringify(req.body),
+    requestBody: JSON.stringify(redactForLogging(req.body)),
     notification: JSON.stringify(notificationObj),
   };
 
@@ -348,3 +552,4 @@ function buildLogMetadata(req) {
 
 exports.handleRequest = handleRequest;
 exports.handleCheckRateLimits = handleCheckRateLimits;
+exports.redactForLogging = redactForLogging;

--- a/functions/handlers.js
+++ b/functions/handlers.js
@@ -189,6 +189,36 @@ async function handleRequest(req, res, payloadHandler) {
 }
 
 /**
+ * Charges the Now Playing counters for a request APNs has already answered.
+ *
+ * Bookkeeping after the fact must never become the result. Apple's answer is the outcome of the
+ * request, and the most important one it can give is that a session token is dead: if a 410 is
+ * replaced by a database exception, Home Assistant is told the relay had an internal error rather
+ * than that it should remove the registration, and it keeps pushing at a token that will never
+ * work again.
+ *
+ * A failure here is still worth knowing about, so it is reported under its own step rather than
+ * folded into the delivery's. Returns the registration counters, or `undefined` when they could
+ * not be written.
+ *
+ * @param {(key: string) => Promise<any>} charge
+ */
+async function chargeNowPlayingQuotas(req, quotas, loggable, charge) {
+  try {
+    const [rateLimits] = await Promise.all(quotas.map(charge));
+    return rateLimits;
+  } catch (err) {
+    try {
+      await reportError(err, 'recordNowPlayingRateLimit', req, loggable);
+    } catch {
+      // Reporting the failure failed too. There is nothing further to try, and the delivery
+      // result still has to reach Home Assistant.
+    }
+    return undefined;
+  }
+}
+
+/**
  * Delivers one Now Playing `update` or `end` straight to APNs.
  *
  * The response is deliberately machine-readable. Home Assistant has to be able to tell a dead
@@ -281,8 +311,14 @@ async function handleNowPlayingRequest(req, res, token) {
     response = await provider.send(prepared.request);
   } catch (err) {
     // The request never reached Apple: a connection or TLS failure, or a timeout.
-    await Promise.all(quotas.map((key) => nowPlayingRateLimiter.recordError(key)));
-    await reportError(err, 'sendNowPlaying', req, loggable);
+    await chargeNowPlayingQuotas(req, quotas, loggable, (key) =>
+      nowPlayingRateLimiter.recordError(key),
+    );
+    try {
+      await reportError(err, 'sendNowPlaying', req, loggable);
+    } catch {
+      // The delivery failure is what Home Assistant needs to hear about, not this.
+    }
     return res.status(502).send({
       errorType: 'ApnsUnavailable',
       errorStep: 'sendNowPlaying',
@@ -293,7 +329,9 @@ async function handleNowPlayingRequest(req, res, token) {
   const outcome = classifyApnsResponse(response);
 
   if (!outcome.ok) {
-    await Promise.all(quotas.map((key) => nowPlayingRateLimiter.recordError(key)));
+    await chargeNowPlayingQuotas(req, quotas, loggable, (key) =>
+      nowPlayingRateLimiter.recordError(key),
+    );
     if (debug) {
       log.info(
         log.entry(metadata, {
@@ -316,9 +354,10 @@ async function handleNowPlayingRequest(req, res, token) {
   }
 
   // The registration's counters are what the response reports, and the destination's are advanced
-  // alongside them so both stay answered.
-  const [rateLimits] = await Promise.all(
-    quotas.map((key) => nowPlayingRateLimiter.recordSuccess(key)),
+  // alongside them so both stay answered. The push has already been delivered, so a failure to
+  // record that leaves `rateLimits` absent from the response rather than losing the delivery.
+  const rateLimits = await chargeNowPlayingQuotas(req, quotas, loggable, (key) =>
+    nowPlayingRateLimiter.recordSuccess(key),
   );
 
   if (debug) {

--- a/functions/handlers.js
+++ b/functions/handlers.js
@@ -299,7 +299,9 @@ async function handleNowPlayingRequest(req, res, token) {
   try {
     await Promise.all(quotas.map((key) => nowPlayingRateLimiter.recordAttempt(key)));
   } catch (err) {
-    return handleError(req, res, loggable, 'getRateLimitDoc', err);
+    // Its own step: `getRateLimitDoc` is the read above, and a failure to write a counter is a
+    // different fault to a failure to read one.
+    return handleError(req, res, loggable, 'recordNowPlayingAttempt', err);
   }
 
   if (debug) {

--- a/functions/now-playing.js
+++ b/functions/now-playing.js
@@ -1,0 +1,315 @@
+'use strict';
+
+const crypto = require('node:crypto');
+
+const { ApnsProvider } = require('./apns-provider');
+
+// Apple's push-to-start event, `start`, is deliberately absent. A Home Assistant Now Playing
+// session exists because the user chose Follow on a media player, so there is nothing to start.
+const SUPPORTED_EVENTS = Object.freeze(['update', 'end']);
+
+// Apple routes a Now Playing push by this suffix on the *containing app's* bundle identifier,
+// not the extension's: `<app id>.RemoteMedia` as the topic fails.
+const NOW_PLAYING_TOPIC_SUFFIX = '.push-type.nowplaying';
+const NOW_PLAYING_PUSH_TYPE = 'nowplaying';
+
+// A bundle identifier is reverse-DNS: alphanumerics and hyphens per label, at least two labels.
+const APP_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]*(\.[A-Za-z0-9][A-Za-z0-9-]*)+$/;
+const MAX_APP_ID_LENGTH = 155;
+
+// Home Assistant's Apple apps all ship under one App Store identifier, TestFlight builds and Mac
+// Catalyst included, so it is built in. Anything else, including the `.dev` identifier debug
+// builds use, has to be named by the deployment: comma-separated, exact identifiers only.
+const OFFICIAL_APP_ID = 'io.robbie.HomeAssistant';
+const ALLOWED_APP_IDS_VARIABLE = 'NOW_PLAYING_APNS_ALLOWED_APP_IDS';
+
+// Apple's documented maximum notification payload. Checked before a connection is opened,
+// because an oversized payload can only be refused.
+const MAX_PAYLOAD_BYTES = 4096;
+
+// A destination token is a device-scoped identifier that can be pushed to. Logs and responses
+// carry this many characters of its SHA-256 instead of the token itself.
+const TOKEN_FINGERPRINT_LENGTH = 16;
+
+/**
+ * Whether this request wants Now Playing delivery rather than FCM.
+ *
+ * @param {object} body
+ */
+function isNowPlayingRequest(body) {
+  return Boolean(body && body.now_playing_token);
+}
+
+/**
+ * Validates a Now Playing request and returns the APNs send it implies, or the reason it cannot.
+ *
+ * Validation stops at what is needed to build safe APNs traffic. The attributes themselves are
+ * Home Assistant's versioned contract with the iOS app: this checks that `id` is present, because
+ * iOS routes the push by it and a payload without one is silently discarded by the device, and
+ * otherwise forwards the object untouched so a newer schema passes through an older relay.
+ *
+ * @param {object} body
+ * @returns {{ ok: boolean, status?: number, error?: object, event?: string,
+ *             request?: { token: string, topic: string, pushType: string, body: Buffer } }}
+ */
+function prepareNowPlaying(body) {
+  const token = body.now_playing_token;
+
+  if (body.live_activity_token) {
+    // One request cannot mean both, and guessing would send the wrong thing to the wrong token.
+    return invalid(
+      400,
+      'AmbiguousRequest',
+      'A request may not carry both live_activity_token and now_playing_token.',
+    );
+  }
+
+  if (typeof token !== 'string' || !/^[0-9a-fA-F]+$/.test(token) || token.length % 2 !== 0) {
+    return invalid(400, 'InvalidNowPlayingToken', 'now_playing_token must be a hex string.');
+  }
+
+  const request = body.now_playing;
+  if (!isPlainObject(request)) {
+    return invalid(400, 'InvalidNowPlayingRequest', 'now_playing must be an object.');
+  }
+
+  const { event, timestamp, attributes } = request;
+
+  if (!SUPPORTED_EVENTS.includes(event)) {
+    return invalid(
+      400,
+      'UnsupportedNowPlayingEvent',
+      `now_playing.event must be one of: ${SUPPORTED_EVENTS.join(', ')}.`,
+    );
+  }
+
+  // Home Assistant owns the ordering clock. APNs sequences a session's pushes by this value and
+  // several state changes can land inside one second, so the relay forwards what it is given
+  // rather than stamping its own. It is not the media position timestamp inside the attributes.
+  if (!Number.isSafeInteger(timestamp) || timestamp <= 0) {
+    return invalid(
+      400,
+      'InvalidNowPlayingTimestamp',
+      'now_playing.timestamp must be a positive integer of Unix seconds.',
+    );
+  }
+
+  if (!isPlainObject(attributes)) {
+    return invalid(400, 'InvalidNowPlayingAttributes', 'now_playing.attributes must be an object.');
+  }
+  if (typeof attributes.id !== 'string' || attributes.id.length === 0) {
+    // iOS matches the push to a live session by this. Without it APNs still answers 200 and the
+    // device throws the push away, which is indistinguishable from a delivery failure.
+    return invalid(
+      400,
+      'MissingNowPlayingSessionId',
+      'now_playing.attributes.id must be a non-empty string.',
+    );
+  }
+
+  const topic = nowPlayingTopic(body.registration_info);
+  if (!topic) {
+    // 403 rather than 400: the request is well formed, this relay just does not serve that app.
+    // The refusal does not name the configured apps.
+    return invalid(
+      403,
+      'UnsupportedApp',
+      'This relay is not configured to send Now Playing updates for that app.',
+    );
+  }
+
+  const payload = Buffer.from(JSON.stringify({ aps: { event, timestamp, attributes } }));
+  if (payload.length > MAX_PAYLOAD_BYTES) {
+    return invalid(
+      413,
+      'PayloadTooLarge',
+      `Now Playing payload is ${payload.length} bytes; APNs allows ${MAX_PAYLOAD_BYTES}.`,
+    );
+  }
+
+  return {
+    ok: true,
+    event,
+    request: { token, topic, pushType: NOW_PLAYING_PUSH_TYPE, body: payload },
+  };
+}
+
+/**
+ * The APNs topic for a registration, or `null` when this relay will not address that app.
+ *
+ * The topic is derived here and never taken from the request: `registration_info.app_id` arrives
+ * in a body to a public endpoint, and it selects an APNs topic under a team-scoped signing key,
+ * so a syntactically valid bundle identifier is not an authorized one. Otherwise anything the
+ * team can sign would be reachable through this endpoint. Matching is exact, and the syntax check
+ * is kept as well, which is what makes a configured `*` harmless: it can only ever match the
+ * literal string `*`, and that is not a bundle identifier.
+ *
+ * Configuration is read per call so a deployment change takes effect without a cold start.
+ *
+ * @param {unknown} registrationInfo
+ * @returns {string | null}
+ */
+function nowPlayingTopic(registrationInfo) {
+  const appId = isPlainObject(registrationInfo) ? registrationInfo.app_id : undefined;
+  if (
+    typeof appId !== 'string' ||
+    appId.length > MAX_APP_ID_LENGTH ||
+    !APP_ID_PATTERN.test(appId)
+  ) {
+    return null;
+  }
+  const configured = (process.env[ALLOWED_APP_IDS_VARIABLE] || '')
+    .split(',')
+    .map((value) => value.trim());
+  if (appId !== OFFICIAL_APP_ID && !configured.includes(appId)) {
+    return null;
+  }
+  return `${appId}${NOW_PLAYING_TOPIC_SUFFIX}`;
+}
+
+// Apple's `reason` is more specific than the status code, so it decides when it is recognised.
+const REASON_ERRORS = new Map([
+  ['Unregistered', 'InvalidToken'],
+  ['BadDeviceToken', 'InvalidToken'],
+  ['DeviceTokenNotForTopic', 'TopicMismatch'],
+  ['TopicDisallowed', 'TopicMismatch'],
+  ['BadTopic', 'TopicMismatch'],
+  ['InvalidProviderToken', 'ProviderAuth'],
+  ['ExpiredProviderToken', 'ProviderAuth'],
+  ['PayloadTooLarge', 'PayloadTooLarge'],
+  ['TooManyRequests', 'ApnsRateLimited'],
+]);
+
+// The same refusals by status, for an answer whose reason is missing or new to us.
+const STATUS_ERRORS = new Map([
+  [403, 'ProviderAuth'],
+  [410, 'InvalidToken'],
+  [413, 'PayloadTooLarge'],
+  [429, 'ApnsRateLimited'],
+]);
+
+const ERROR_HTTP_STATUS = new Map([
+  ['InvalidToken', 410],
+  ['TopicMismatch', 400],
+  ['ProviderAuth', 502],
+  ['PayloadTooLarge', 413],
+  ['ApnsRateLimited', 429],
+  ['ApnsUnavailable', 502],
+  ['ApnsError', 502],
+]);
+
+/**
+ * Classifies Apple's answer so Home Assistant can act on it without reading prose.
+ *
+ * The distinction that matters: `InvalidToken` means this session's token is dead and the
+ * registration should go, while everything else is the relay's or the app's problem and must
+ * never cost a user their registration. An unrecognised refusal is therefore `ApnsError`, not
+ * a guess at a dead token.
+ *
+ * @param {{ status: number, reason: string | null }} response
+ * @returns {{ ok: boolean, errorType?: string, httpStatus: number }}
+ */
+function classifyApnsResponse({ status, reason }) {
+  if (status === 200) {
+    return { ok: true, httpStatus: 201 };
+  }
+  const errorType =
+    REASON_ERRORS.get(reason) ||
+    STATUS_ERRORS.get(status) ||
+    (status >= 500 ? 'ApnsUnavailable' : 'ApnsError');
+  return { ok: false, errorType, httpStatus: ERROR_HTTP_STATUS.get(errorType) };
+}
+
+/**
+ * The rate-limit identity of a destination token.
+ *
+ * Lower-cased first, because the token is validated as case-insensitive hex and one device written
+ * two ways must not be handed two quotas. A full digest because this is a storage key: at 16 hex
+ * characters a collision is cheap enough to be worth finding, and a collision here lets one device
+ * spend another's quota.
+ *
+ * @param {string} token
+ */
+function destinationIdentity(token) {
+  return crypto.createHash('sha256').update(token.toLowerCase()).digest('hex');
+}
+
+/**
+ * A short, non-reversible label for a destination token, for logs and responses.
+ *
+ * A prefix of the same digest, so one device is one label however its token was cased.
+ *
+ * @param {string} token
+ */
+function tokenFingerprint(token) {
+  return destinationIdentity(token).slice(0, TOKEN_FINGERPRINT_LENGTH);
+}
+
+/**
+ * The process-wide provider, built from deployment configuration on first use.
+ *
+ * `null` when Now Playing is not configured, which is the state of any deployment that has not
+ * been given a key. The request is then refused rather than failing inside a send.
+ *
+ * @type {ApnsProvider | null | undefined}
+ */
+let provider;
+
+/** @returns {ApnsProvider | null} */
+function nowPlayingProvider() {
+  if (provider !== undefined) {
+    return provider;
+  }
+  const key = process.env.NOW_PLAYING_APNS_KEY;
+  const keyId = process.env.NOW_PLAYING_APNS_KEY_ID;
+  const teamId = process.env.NOW_PLAYING_APNS_TEAM_ID;
+  if (!key || !keyId || !teamId) {
+    provider = null;
+    return provider;
+  }
+  provider = new ApnsProvider({
+    // Deployment secrets keep newlines awkwardly; accept an escaped form as well as a real one.
+    key: key.replace(/\\n/g, '\n'),
+    keyId,
+    teamId,
+    // iOS 27 issues these tokens against production even for a development-signed build. That is
+    // Apple's behaviour rather than a rule this relay asserts, so the environment stays
+    // configurable and defaults to what works.
+    production: process.env.NOW_PLAYING_APNS_PRODUCTION !== 'false',
+  });
+  return provider;
+}
+
+/** Test seam. Replaces the cached provider; `undefined` restores configuration lookup. */
+function setNowPlayingProvider(next) {
+  provider = next;
+}
+
+/**
+ * @param {number} status
+ * @param {string} errorType
+ * @param {string} message
+ * @returns {{ ok: boolean, status: number, error: object }}
+ */
+function invalid(status, errorType, message) {
+  return { ok: false, status, error: { errorType, message } };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, any>}
+ */
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+module.exports = {
+  isNowPlayingRequest,
+  prepareNowPlaying,
+  classifyApnsResponse,
+  destinationIdentity,
+  tokenFingerprint,
+  nowPlayingProvider,
+  setNowPlayingProvider,
+  MAX_PAYLOAD_BYTES,
+};

--- a/functions/now-playing.js
+++ b/functions/now-playing.js
@@ -53,7 +53,7 @@ function isNowPlayingRequest(body) {
  *             request?: { token: string, topic: string, pushType: string, body: Buffer } }}
  */
 function prepareNowPlaying(body) {
-  const token = body.now_playing_token;
+  const supplied = body.now_playing_token;
 
   if (body.live_activity_token) {
     // One request cannot mean both, and guessing would send the wrong thing to the wrong token.
@@ -64,9 +64,17 @@ function prepareNowPlaying(body) {
     );
   }
 
-  if (typeof token !== 'string' || !/^[0-9a-fA-F]+$/.test(token) || token.length % 2 !== 0) {
+  if (
+    typeof supplied !== 'string' ||
+    !/^[0-9a-fA-F]+$/.test(supplied) ||
+    supplied.length % 2 !== 0
+  ) {
     return invalid(400, 'InvalidNowPlayingToken', 'now_playing_token must be a hex string.');
   }
+  // Hex is case-insensitive and a caller may send either, so it is settled here rather than at
+  // each use. Everything downstream then agrees on one spelling: the device path APNs is given,
+  // the quota the send is charged to, and the fingerprint it is logged under.
+  const token = supplied.toLowerCase();
 
   const request = body.now_playing;
   if (!isPlainObject(request)) {

--- a/functions/rate-limiter/firestore-rate-limiter.js
+++ b/functions/rate-limiter/firestore-rate-limiter.js
@@ -31,11 +31,14 @@ class FirestoreRateLimiter {
    *
    * @param {number} [maxNotificationsPerDay] - Maximum notifications allowed per day
    * @param {boolean} [debug=false] - Whether to enable debug logging
+   * @param {string} [keyPrefix=''] - Counter namespace. Empty for the notification quota, which
+   *   keeps its existing document paths.
    */
-  constructor(maxNotificationsPerDay, debug = false) {
+  constructor(maxNotificationsPerDay, debug = false, keyPrefix = '') {
     this.db = db;
     this.maxNotificationsPerDay = maxNotificationsPerDay;
     this.debug = debug;
+    this.keyPrefix = keyPrefix;
   }
 
   /**
@@ -47,7 +50,11 @@ class FirestoreRateLimiter {
    */
   _getDocRef(token) {
     const today = getToday();
-    return this.db.collection('rateLimits').doc(today).collection('tokens').doc(token);
+    return this.db
+      .collection('rateLimits')
+      .doc(today)
+      .collection('tokens')
+      .doc(`${this.keyPrefix}${token}`);
   }
 
   /**

--- a/functions/rate-limiter/util.js
+++ b/functions/rate-limiter/util.js
@@ -21,6 +21,22 @@
 const TWENTY_FOUR_HOURS_IN_MS = 86400000;
 
 /**
+ * Key prefix for the Remote Now Playing quota, which is metered separately so that a day of
+ * listening cannot stop a user's real notifications. The notification bucket keeps an empty
+ * prefix, so its keys and document paths are exactly what they always were.
+ */
+const NOW_PLAYING_KEY_PREFIX = 'nowplaying:';
+
+/**
+ * Distinguishes the counter kept for a push's destination device from the one kept for the
+ * registration that asked for it. Both live in the Now Playing namespace above.
+ *
+ * A Companion token always contains a colon and a destination identity is a hex digest, so the two
+ * could not collide even without this; it is here so a key says which of the two it is.
+ */
+const NOW_PLAYING_DESTINATION_PREFIX = 'device:';
+
+/**
  * Gets today's date in YYYYMMDD format for use in Valkey keys.
  *
  * @private
@@ -36,3 +52,5 @@ function getToday() {
 
 exports.getToday = getToday;
 exports.TWENTY_FOUR_HOURS_IN_MS = TWENTY_FOUR_HOURS_IN_MS;
+exports.NOW_PLAYING_KEY_PREFIX = NOW_PLAYING_KEY_PREFIX;
+exports.NOW_PLAYING_DESTINATION_PREFIX = NOW_PLAYING_DESTINATION_PREFIX;

--- a/functions/rate-limiter/valkey-rate-limiter.js
+++ b/functions/rate-limiter/valkey-rate-limiter.js
@@ -66,14 +66,23 @@ class ValkeyRateLimiter {
    * @param {boolean} [debug=false] - Whether to enable debug logging
    * @param {string} [valkeyHost] - Valkey Cluster host
    * @param {number} [valkeyPort] - Valkey Cluster port
+   * @param {string} [keyPrefix=''] - Counter namespace. Empty for the notification quota, which
+   *   keeps its existing keys.
    */
-  constructor(maxNotificationsPerDay, debug = false, valkeyHost = 'localhost', valkeyPort = 6379) {
+  constructor(
+    maxNotificationsPerDay,
+    debug = false,
+    valkeyHost = 'localhost',
+    valkeyPort = 6379,
+    keyPrefix = '',
+  ) {
     this.valkeyHost = valkeyHost;
     this.valkeyPort = valkeyPort;
     this.maxNotificationsPerDay = maxNotificationsPerDay;
     this.debug = debug;
     this.connected = false;
     this.client = null;
+    this.keyPrefix = keyPrefix;
   }
 
   async connect() {
@@ -97,7 +106,7 @@ class ValkeyRateLimiter {
    */
   _getValkeyKey(token) {
     const today = getToday();
-    return `rate_limit:${token}:${today}`;
+    return `rate_limit:${this.keyPrefix}${token}:${today}`;
   }
 
   /**

--- a/functions/test/apns-provider.test.js
+++ b/functions/test/apns-provider.test.js
@@ -1,0 +1,272 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const { EventEmitter } = require('node:events');
+
+const { ApnsProvider } = require('../apns-provider');
+
+// A throwaway P-256 key, generated per run. Never a real credential, and never asserted on.
+const { privateKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+const KEY_PEM = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+const KEY_ID = 'TESTKEYID1';
+const TEAM_ID = 'TESTTEAM01';
+const TOKEN = 'de1ec7ab1ede1ec7ab1ede1ec7ab1ede';
+const TOPIC = 'io.robbie.HomeAssistant.push-type.nowplaying';
+
+/** A stand-in for one HTTP/2 stream, driven by the test. */
+class FakeStream extends EventEmitter {
+  constructor() {
+    super();
+    this.headers = null;
+    this.written = null;
+    this.closedWith = null;
+    this.timeoutHandler = null;
+  }
+
+  setTimeout(ms, handler) {
+    this.timeoutMs = ms;
+    this.timeoutHandler = handler;
+  }
+
+  end(body) {
+    this.written = body;
+    this.emit('written');
+  }
+
+  close(code) {
+    this.closedWith = code;
+  }
+
+  /** Plays back an APNs answer. */
+  respond(status, { apnsId = 'APNS-ID-1', body = null } = {}) {
+    this.emit('response', { ':status': status, 'apns-id': apnsId });
+    if (body !== null) {
+      this.emit('data', Buffer.from(typeof body === 'string' ? body : JSON.stringify(body)));
+    }
+    this.emit('end');
+  }
+}
+
+/** A stand-in for an HTTP/2 session. */
+class FakeSession extends EventEmitter {
+  constructor() {
+    super();
+    this.closed = false;
+    this.destroyed = false;
+    this.requests = [];
+    this.throwOnRequest = null;
+  }
+
+  request(headers) {
+    if (this.throwOnRequest) {
+      const err = this.throwOnRequest;
+      this.throwOnRequest = null;
+      throw err;
+    }
+    const stream = new FakeStream();
+    stream.headers = headers;
+    this.requests.push(stream);
+    return stream;
+  }
+
+  close() {
+    this.closed = true;
+    this.emit('close');
+  }
+}
+
+const makeProvider = (overrides = {}) => {
+  const sessions = [];
+  const hosts = [];
+  const provider = new ApnsProvider({
+    key: KEY_PEM,
+    keyId: KEY_ID,
+    teamId: TEAM_ID,
+    connect: (host) => {
+      hosts.push(host);
+      const session = new FakeSession();
+      sessions.push(session);
+      return session;
+    },
+    ...overrides,
+  });
+  return { provider, sessions, hosts };
+};
+
+const startSend = (provider) =>
+  provider.send({ token: TOKEN, topic: TOPIC, pushType: 'nowplaying', body: Buffer.from('{}') });
+
+/** Drives one send to completion against the fake transport. */
+const sendAndRespond = async (provider, sessions, status, options) => {
+  const pending = startSend(provider);
+  const session = sessions[sessions.length - 1];
+  const stream = session.requests[session.requests.length - 1];
+  await new Promise((resolve) => (stream.written ? resolve() : stream.once('written', resolve)));
+  stream.respond(status, options);
+  return { result: await pending, stream };
+};
+
+const decodeJwt = (bearer) => {
+  const [header, claims, signature] = bearer.replace(/^bearer /, '').split('.');
+  return {
+    header: JSON.parse(Buffer.from(header, 'base64url').toString('utf8')),
+    claims: JSON.parse(Buffer.from(claims, 'base64url').toString('utf8')),
+    signature: Buffer.from(signature, 'base64url'),
+    signingInput: `${header}.${claims}`,
+  };
+};
+
+describe('construction', () => {
+  test.each([['key'], ['keyId'], ['teamId']])('refuses to build without %s', (field) => {
+    expect(() => makeProvider({ [field]: '' })).toThrow(/requires key, keyId and teamId/);
+  });
+
+  /// iOS 27 issues Now Playing tokens against production even for a development-signed build,
+  /// but that is Apple's behaviour and not a rule to hardcode.
+  test('defaults to production and can be pointed at sandbox', () => {
+    expect(makeProvider().provider.host).toBe('https://api.push.apple.com');
+    expect(makeProvider({ production: false }).provider.host).toBe(
+      'https://api.sandbox.push.apple.com',
+    );
+  });
+});
+
+describe('the provider JWT', () => {
+  test('is a verifiable ES256 JWS with the configured key id and team', () => {
+    const { provider } = makeProvider({ now: () => 1788749001000 });
+    const { header, claims, signature, signingInput } = decodeJwt(provider.authorizationToken());
+
+    expect(header).toEqual({ alg: 'ES256', kid: KEY_ID });
+    expect(claims).toEqual({ iss: TEAM_ID, iat: 1788749001 });
+    // Raw R||S, as JWS requires, rather than the DER encoding Node signs with by default.
+    expect(signature).toHaveLength(64);
+    expect(
+      crypto.verify(
+        'sha256',
+        Buffer.from(signingInput),
+        { key: privateKey, dsaEncoding: 'ieee-p1363' },
+        signature,
+      ),
+    ).toBe(true);
+  });
+
+  /// Apple rejects a provider token older than an hour, so the refresh has to land inside that
+  /// while still not re-signing per push.
+  test('is cached, then re-signed before Apple one-hour maximum', () => {
+    let now = 1788749001000;
+    const { provider } = makeProvider({ now: () => now });
+    const first = provider.authorizationToken();
+
+    now += 40 * 60 * 1000;
+    expect(provider.authorizationToken()).toBe(first);
+
+    now += 20 * 60 * 1000;
+    const second = provider.authorizationToken();
+    expect(second).not.toBe(first);
+    expect(decodeJwt(second).claims.iat).toBeGreaterThan(decodeJwt(first).claims.iat);
+  });
+});
+
+describe('the APNs request', () => {
+  test('is a POST to the device path with the Now Playing headers', async () => {
+    const { provider, sessions, hosts } = makeProvider();
+    const { stream } = await sendAndRespond(provider, sessions, 200);
+
+    expect(hosts).toEqual(['https://api.push.apple.com']);
+    expect(stream.headers[':method']).toBe('POST');
+    expect(stream.headers[':path']).toBe(`/3/device/${TOKEN}`);
+    expect(stream.headers['apns-push-type']).toBe('nowplaying');
+    expect(stream.headers['apns-topic']).toBe(TOPIC);
+    expect(stream.headers['content-type']).toBe('application/json');
+    expect(stream.headers.authorization).toMatch(/^bearer [\w-]+\.[\w-]+\.[\w-]+$/);
+  });
+
+  test('reuses one connection across sends', async () => {
+    const { provider, sessions } = makeProvider();
+    await sendAndRespond(provider, sessions, 200);
+    await sendAndRespond(provider, sessions, 200);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].requests).toHaveLength(2);
+  });
+});
+
+describe('the APNs response', () => {
+  test('a 200 resolves with the apns-id', async () => {
+    const { provider, sessions } = makeProvider();
+    const { result } = await sendAndRespond(provider, sessions, 200, { apnsId: 'ABC-123' });
+    expect(result).toEqual({ status: 200, apnsId: 'ABC-123', reason: null });
+  });
+
+  /// A refusal is an answer, not a failure: it resolves so the caller can classify it.
+  test('a refusal resolves with the status and Apple reason', async () => {
+    const { provider, sessions } = makeProvider();
+    const { result } = await sendAndRespond(provider, sessions, 410, {
+      body: { reason: 'Unregistered' },
+    });
+    expect(result).toEqual({ status: 410, apnsId: 'APNS-ID-1', reason: 'Unregistered' });
+  });
+
+  test('a body that is not the documented JSON does not throw', async () => {
+    const { provider, sessions } = makeProvider();
+    const { result } = await sendAndRespond(provider, sessions, 503, { body: '<html>oops</html>' });
+    expect(result).toEqual({ status: 503, apnsId: 'APNS-ID-1', reason: null });
+  });
+});
+
+describe('transport failures', () => {
+  test('a stream error rejects', async () => {
+    const { provider, sessions } = makeProvider();
+    const pending = startSend(provider);
+    sessions[0].requests[0].emit('error', new Error('ECONNRESET'));
+    await expect(pending).rejects.toThrow('ECONNRESET');
+  });
+
+  test('a timeout cancels the stream and rejects', async () => {
+    const { provider, sessions } = makeProvider();
+    const pending = startSend(provider);
+    const stream = sessions[0].requests[0];
+    expect(stream.timeoutMs).toBeGreaterThan(0);
+    stream.timeoutHandler();
+    await expect(pending).rejects.toThrow('timed out');
+    expect(stream.closedWith).toBeDefined();
+  });
+
+  test('a request that cannot even be opened rejects and drops the connection', async () => {
+    const { provider, sessions } = makeProvider();
+    provider.connection().throwOnRequest = new Error('session destroyed');
+    await expect(startSend(provider)).rejects.toThrow('session destroyed');
+    expect(provider.session).toBeNull();
+    // The next send opens a fresh one rather than reusing the broken session.
+    await sendAndRespond(provider, sessions, 200);
+    expect(sessions).toHaveLength(2);
+  });
+
+  /// Apple sends GOAWAY routinely; it is a reconnect, not a failure. A session error must also
+  /// never surface as an unhandled exception, which would take the process down.
+  test.each([['goaway'], ['close'], ['error']])(
+    'a session %s event forces a reconnect without throwing',
+    async (event) => {
+      const { provider, sessions } = makeProvider();
+      await sendAndRespond(provider, sessions, 200);
+      expect(() => sessions[0].emit(event, new Error('bye'))).not.toThrow();
+      expect(provider.session).toBeNull();
+      await sendAndRespond(provider, sessions, 200);
+      expect(sessions).toHaveLength(2);
+    },
+  );
+});
+
+describe('secrecy', () => {
+  test('the provider does not stringify its credentials', async () => {
+    const { provider, sessions } = makeProvider();
+    await sendAndRespond(provider, sessions, 200);
+    const serialized = JSON.stringify(provider, (key, value) =>
+      typeof value === 'object' && value !== null && value.constructor === Object
+        ? value
+        : String(value),
+    );
+    expect(serialized).not.toContain('BEGIN PRIVATE KEY');
+    expect(serialized).not.toContain(KEY_PEM.split('\n')[1]);
+  });
+});

--- a/functions/test/now-playing-handler.test.js
+++ b/functions/test/now-playing-handler.test.js
@@ -1,0 +1,460 @@
+'use strict';
+
+const {
+  createMockRequest,
+  createMockResponse,
+  createMockPayloadHandler,
+  createMockDocRef,
+  createMockRateLimitData,
+} = require('./utils/mock-factories');
+
+const mockMessaging = { send: jest.fn() };
+const mockFirestore = { collection: jest.fn(), runTransaction: jest.fn() };
+const mockFunctions = {
+  config: jest.fn(() => ({})),
+  logger: { info: jest.fn(), warn: jest.fn() },
+  region: jest.fn().mockReturnThis(),
+  runWith: jest.fn().mockReturnThis(),
+  https: { onRequest: jest.fn() },
+};
+const logWrites = [];
+const mockLogging = {
+  log: jest.fn(() => ({
+    write: jest.fn((entry, callback) => callback()),
+    entry: jest.fn((metadata, payload) => {
+      logWrites.push(payload);
+      return {};
+    }),
+    debug: jest.fn(),
+    info: jest.fn(),
+    alert: jest.fn(),
+  })),
+};
+
+jest.mock('firebase-functions/v1', () => mockFunctions);
+jest.mock('@google-cloud/logging', () => ({ Logging: jest.fn(() => mockLogging) }));
+jest.mock('firebase-admin/app', () => ({ initializeApp: jest.fn() }));
+jest.mock('firebase-admin/firestore', () => ({
+  getFirestore: jest.fn(() => mockFirestore),
+  Timestamp: { fromDate: jest.fn(() => 'mock-timestamp') },
+}));
+jest.mock('firebase-admin/messaging', () => ({ getMessaging: jest.fn(() => mockMessaging) }));
+
+const handlers = require('../handlers.js');
+const legacy = require('../legacy.js');
+const { destinationIdentity, setNowPlayingProvider, tokenFingerprint } = require('../now-playing');
+const { NOW_PLAYING_DESTINATION_PREFIX, NOW_PLAYING_KEY_PREFIX } = require('../rate-limiter/util');
+
+const TOKEN = 'de1ec7ab1ede1ec7ab1ede1ec7ab1ede';
+const FCM_TOKEN = 'test:token123';
+const NOW_PLAYING_DOC = `${NOW_PLAYING_KEY_PREFIX}${FCM_TOKEN}`;
+const DESTINATION_DOC = `${NOW_PLAYING_KEY_PREFIX}${NOW_PLAYING_DESTINATION_PREFIX}${destinationIdentity(TOKEN)}`;
+
+/** Document ids the rate limiters addressed, so which quota was charged is observable. */
+const docIds = [];
+/** Documents a test has declared full, so one quota can be exhausted without the other. */
+const limitedDocs = new Set();
+/** Live counters per document. */
+const counters = new Map();
+/** What a test asked every not-yet-written document to start at, if anything. */
+let baseline = null;
+
+/** The counters a document currently holds, or `null` when it does not exist yet. */
+const stateOf = (id) => {
+  if (limitedDocs.has(id)) {
+    return createMockRateLimitData({
+      attemptsCount: 5001,
+      deliveredCount: 5001,
+      totalCount: 5001,
+    });
+  }
+  if (counters.has(id)) return counters.get(id);
+  return baseline;
+};
+
+const nowPlayingBody = (overrides = {}) => ({
+  push_token: FCM_TOKEN,
+  now_playing_token: TOKEN,
+  registration_info: {
+    app_id: 'io.robbie.HomeAssistant',
+    app_version: '2026.9.1',
+    webhook_id: 'webhook-1',
+    os_version: '27.0',
+  },
+  now_playing: {
+    event: 'update',
+    timestamp: 1788749001,
+    attributes: { id: 'remote-media-123', schemaVersion: 1 },
+  },
+  ...overrides,
+});
+
+/** A provider that records what it was asked to send. */
+const fakeProvider = (response = { status: 200, apnsId: 'APNS-1', reason: null }) => ({
+  sent: [],
+  send(request) {
+    this.sent.push(request);
+    return response instanceof Error ? Promise.reject(response) : Promise.resolve(response);
+  },
+});
+
+describe('Now Playing delivery through sendPushNotification', () => {
+  let req, res, docRef, docSnapshot;
+
+  /** Starts every Now Playing counter at `count`. */
+  const withCounters = (count) => {
+    baseline = createMockRateLimitData({
+      attemptsCount: count,
+      deliveredCount: count,
+      totalCount: count,
+    });
+    docSnapshot.exists = true;
+    docSnapshot.data.mockReturnValue(baseline);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logWrites.length = 0;
+    mockMessaging.send.mockResolvedValue('mock-message-id');
+
+    res = createMockResponse();
+    docSnapshot = { exists: false, data: jest.fn(() => createMockRateLimitData()) };
+    docRef = createMockDocRef(docSnapshot);
+    docIds.length = 0;
+    limitedDocs.clear();
+    counters.clear();
+    baseline = null;
+
+    // Counters are per document, because the two Now Playing quotas are two documents and a test
+    // has to be able to fill one without filling the other.
+    mockFirestore.collection.mockReturnValue({
+      doc: jest.fn(() => ({
+        collection: jest.fn(() => ({
+          doc: jest.fn((id) => {
+            docIds.push(id);
+            return {
+              id,
+              // `checkRateLimit` reads through this, so it has to see the same per-document
+              // counters the transaction does.
+              get: async () => {
+                const current = stateOf(id);
+                return { exists: current !== null, data: () => current || {} };
+              },
+              set: (data) => docRef.set(data),
+              update: (data) => docRef.update(data),
+            };
+          }),
+        })),
+      })),
+    });
+    mockFirestore.runTransaction.mockImplementation(async (callback) =>
+      callback({
+        get: jest.fn((ref) => {
+          const current = stateOf(ref.id);
+          return { exists: current !== null, data: () => current || {} };
+        }),
+        set: jest.fn((ref, data) => {
+          counters.set(ref.id, { ...data });
+          docSnapshot.exists = true;
+          docSnapshot.data = jest.fn(() => ({ ...data }));
+          docRef.set(data);
+        }),
+        update: jest.fn((ref, data) => {
+          const current = stateOf(ref.id);
+          if (current) {
+            counters.set(ref.id, { ...current, ...data });
+            docSnapshot.data = jest.fn(() => ({ ...current, ...data }));
+          }
+          docRef.update(data);
+        }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    setNowPlayingProvider(undefined);
+  });
+
+  describe('routing', () => {
+    test('an ordinary notification still goes through Firebase', async () => {
+      const provider = fakeProvider();
+      setNowPlayingProvider(provider);
+      req = createMockRequest();
+      await handlers.handleRequest(req, res, createMockPayloadHandler());
+
+      expect(mockMessaging.send).toHaveBeenCalledTimes(1);
+      expect(provider.sent).toHaveLength(0);
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    /// Live Activities work through Firebase Admin's own liveActivityToken support and must not
+    /// be re-routed onto the direct provider.
+    test('a Live Activity still goes through Firebase with liveActivityToken', async () => {
+      const provider = fakeProvider();
+      setNowPlayingProvider(provider);
+      req = createMockRequest({
+        body: {
+          push_token: FCM_TOKEN,
+          live_activity_token: 'la-token-abc',
+          message: 'Doing a thing',
+          data: { event: 'update', tag: 'laundry' },
+          registration_info: { app_id: 'io.robbie.HomeAssistant', app_version: '2026.9.1' },
+        },
+      });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(provider.sent).toHaveLength(0);
+      expect(mockMessaging.send).toHaveBeenCalledTimes(1);
+      expect(mockMessaging.send.mock.calls[0][0].apns.liveActivityToken).toBe('la-token-abc');
+    });
+
+    test('a now_playing_token goes to the direct provider, not Firebase', async () => {
+      const provider = fakeProvider();
+      setNowPlayingProvider(provider);
+      req = createMockRequest({ body: nowPlayingBody() });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(mockMessaging.send).not.toHaveBeenCalled();
+      expect(provider.sent).toHaveLength(1);
+      expect(provider.sent[0]).toMatchObject({
+        token: TOKEN,
+        topic: 'io.robbie.HomeAssistant.push-type.nowplaying',
+        pushType: 'nowplaying',
+      });
+    });
+
+    /// The ordinary FCM token is still required: it is the registration and metering identity.
+    test('a Now Playing request without a Companion token is refused', async () => {
+      setNowPlayingProvider(fakeProvider());
+      req = createMockRequest({ body: { ...nowPlayingBody(), push_token: undefined } });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    /// Every refusal from this path carries one step name, so Home Assistant only has to read
+    /// `errorType`.
+    test.each([
+      [
+        'a request-shape refusal',
+        () => nowPlayingBody({ live_activity_token: 'la-token' }),
+        400,
+        'AmbiguousRequest',
+      ],
+      [
+        'an app this relay does not serve',
+        () => nowPlayingBody({ registration_info: { app_id: 'evil.example.app' } }),
+        403,
+        'UnsupportedApp',
+      ],
+    ])('%s is refused before any APNs traffic', async (_label, body, status, errorType) => {
+      const provider = fakeProvider();
+      setNowPlayingProvider(provider);
+      req = createMockRequest({ body: body() });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(provider.sent).toHaveLength(0);
+      expect(mockMessaging.send).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(status);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ errorType, errorStep: 'sendNowPlaying' }),
+      );
+      // Nothing was charged either.
+      expect(docRef.set).not.toHaveBeenCalled();
+      // And the refusal discloses neither the destination token nor the configured allowlist.
+      const serialized = JSON.stringify(res.send.mock.calls[0][0]);
+      expect(serialized).not.toContain(TOKEN);
+      expect(serialized).not.toContain('io.robbie');
+    });
+
+    test('a deployment with no credentials says so instead of failing obscurely', async () => {
+      setNowPlayingProvider(null);
+      req = createMockRequest({ body: nowPlayingBody() });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(mockMessaging.send).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(501);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ errorType: 'NowPlayingNotConfigured' }),
+      );
+    });
+  });
+
+  describe('the answer to Home Assistant', () => {
+    test('a delivery reports the apns-id and a fingerprint rather than the token', async () => {
+      setNowPlayingProvider(fakeProvider({ status: 200, apnsId: 'APNS-42', reason: null }));
+      req = createMockRequest({ body: nowPlayingBody() });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = res.send.mock.calls[0][0];
+      expect(body).toMatchObject({ messageId: 'APNS-42', target: tokenFingerprint(TOKEN) });
+      expect(body.sentPayload.aps.attributes.id).toBe('remote-media-123');
+      expect(JSON.stringify(body)).not.toContain(TOKEN);
+    });
+
+    /// Only a genuinely dead token may carry `InvalidToken`: Home Assistant unregisters on it,
+    /// and losing a registration over a topic or credential fault would silently stop a feature
+    /// the user never turned off.
+    /// The mapping itself is covered exhaustively against `classifyApnsResponse`. What matters
+    /// here is that its verdict reaches the response: the one that retires a registration, one
+    /// that must not be mistaken for it, and a refusal nobody has seen before.
+    test.each([
+      [410, 'Unregistered', 410, 'InvalidToken'],
+      [400, 'DeviceTokenNotForTopic', 400, 'TopicMismatch'],
+      [400, 'SomethingNewFromApple', 502, 'ApnsError'],
+    ])('APNs %i %s answers HTTP %i %s', async (apnsStatus, reason, httpStatus, errorType) => {
+      setNowPlayingProvider(fakeProvider({ status: apnsStatus, apnsId: 'APNS-1', reason }));
+      req = createMockRequest({ body: nowPlayingBody() });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(res.status).toHaveBeenCalledWith(httpStatus);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ errorType, errorCode: reason, errorStep: 'sendNowPlaying' }),
+      );
+    });
+
+    test('a connection failure is an infrastructure error, not a dead token', async () => {
+      setNowPlayingProvider(fakeProvider(new Error('ECONNRESET')));
+      req = createMockRequest({ body: nowPlayingBody() });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(res.status).toHaveBeenCalledWith(502);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ errorType: 'ApnsUnavailable', errorStep: 'sendNowPlaying' }),
+      );
+    });
+  });
+
+  describe('rate limiting', () => {
+    /// Metering is on the Companion FCM token, never the session token: that one belongs to a
+    /// single Follow session and rotates, so a client could reset its quota by re-following.
+    /// Two counters. The Companion one is the identity every other quota here uses; the
+    /// destination one exists because this path only ever checks that token's shape, so a caller
+    /// can make up a new one per request and would otherwise have unlimited access to one phone.
+    test('charges both the registration and the destination counter', async () => {
+      setNowPlayingProvider(fakeProvider());
+      req = createMockRequest({ body: nowPlayingBody() });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(docIds).toContain(NOW_PLAYING_DOC);
+      expect(docIds).toContain(DESTINATION_DOC);
+      // Keys are a digest, never the token they stand for.
+      expect(docIds.join(' ')).not.toContain(TOKEN);
+      expect(docRef.set).toHaveBeenCalledWith(expect.objectContaining({ attemptsCount: 1 }));
+      expect(docRef.update).toHaveBeenCalledWith(expect.objectContaining({ deliveredCount: 1 }));
+    });
+
+    test('an invented Companion token shares the destination counter with a real one', async () => {
+      setNowPlayingProvider(fakeProvider());
+      req = createMockRequest({
+        body: { ...nowPlayingBody(), push_token: 'invented:1' },
+      });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      // Its own registration bucket, which is exactly why the destination bucket has to exist.
+      expect(docIds).toContain(`${NOW_PLAYING_KEY_PREFIX}invented:1`);
+      expect(docIds).toContain(DESTINATION_DOC);
+    });
+
+    /// The token is validated as case-insensitive hex, so the same device written two ways must
+    /// not be handed two buckets.
+    test('the destination counter does not care how the token is cased', async () => {
+      setNowPlayingProvider(fakeProvider());
+      req = createMockRequest({
+        body: { ...nowPlayingBody(), now_playing_token: TOKEN.toUpperCase() },
+      });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(docIds).toContain(DESTINATION_DOC);
+    });
+
+    /// Either counter refuses on its own. The destination row uses an invented Companion token so
+    /// only the destination counter is full, which is the case a registration-keyed quota alone
+    /// would have let through.
+    ///
+    /// Nothing is charged either way. Charging one counter for a request the other refuses would
+    /// leave an attempt that no success or error ever answers, and the visible
+    /// "Notifications Rate Limited" push belongs to the notification quota, not to this one.
+    test.each([
+      ['the registration', () => withCounters(5001), FCM_TOKEN],
+      ['the destination', () => limitedDocs.add(DESTINATION_DOC), 'invented:2'],
+    ])(
+      'a target over %s ceiling is refused, and charges nothing',
+      async (_label, fill, pushToken) => {
+        const provider = fakeProvider();
+        setNowPlayingProvider(provider);
+        fill();
+        req = createMockRequest({ body: { ...nowPlayingBody(), push_token: pushToken } });
+        await handlers.handleRequest(req, res, legacy.createPayload);
+
+        expect(provider.sent).toHaveLength(0);
+        expect(mockMessaging.send).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(429);
+        const body = res.send.mock.calls[0][0];
+        expect(body).toMatchObject({ errorType: 'RateLimited', target: pushToken });
+        expect(JSON.stringify(body)).not.toContain(TOKEN);
+        expect(docRef.set).not.toHaveBeenCalled();
+        expect(docRef.update).not.toHaveBeenCalled();
+      },
+    );
+
+    test('an ordinary notification still charges the notification counter', async () => {
+      req = createMockRequest();
+      await handlers.handleRequest(req, res, createMockPayloadHandler());
+
+      expect(docIds).toContain(FCM_TOKEN);
+      expect(docIds).not.toContain(NOW_PLAYING_DOC);
+    });
+
+    /// The whole point of the separate quota: a day of listening must not stop real
+    /// notifications, and a target out of notification quota is not out of Now Playing quota.
+    test('a target over the notification quota can still send Now Playing updates', async () => {
+      const provider = fakeProvider();
+      setNowPlayingProvider(provider);
+      withCounters(900);
+      req = createMockRequest({ body: nowPlayingBody() });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(provider.sent).toHaveLength(1);
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    /// Over MAX_NOW_PLAYING_UPDATES_PER_DAY. The visible "Notifications Rate Limited" push
+    /// belongs to the notification quota alone; this ceiling is a machine-readable refusal.
+  });
+
+  describe('logging', () => {
+    test('the destination token is redacted from error reports', () => {
+      const body = nowPlayingBody();
+      const redacted = handlers.redactForLogging(body);
+      expect(JSON.stringify(redacted)).not.toContain(TOKEN);
+      expect(redacted.now_playing_token).toBe(`[redacted:${tokenFingerprint(TOKEN)}]`);
+      // Everything else a maintainer needs is still there.
+      expect(redacted.registration_info).toEqual(body.registration_info);
+      expect(redacted.now_playing).toEqual(body.now_playing);
+    });
+
+    test('an ordinary request body is returned untouched', () => {
+      const body = { push_token: FCM_TOKEN, message: 'hi' };
+      expect(handlers.redactForLogging(body)).toBe(body);
+      expect(handlers.redactForLogging(undefined)).toBeUndefined();
+    });
+
+    test('no log entry from a Now Playing send contains the token, a key or a bearer', async () => {
+      process.env.DEBUG = 'true';
+      jest.resetModules();
+      const freshHandlers = require('../handlers.js');
+      require('../now-playing').setNowPlayingProvider(fakeProvider());
+      req = createMockRequest({ body: nowPlayingBody() });
+      await freshHandlers.handleRequest(req, res, legacy.createPayload);
+      delete process.env.DEBUG;
+
+      const serialized = JSON.stringify(logWrites);
+      expect(serialized).not.toContain(TOKEN);
+      expect(serialized).not.toContain('bearer ');
+      expect(serialized).not.toContain('BEGIN PRIVATE KEY');
+      // The fingerprint is what correlation uses instead.
+      expect(serialized).toContain(tokenFingerprint(TOKEN));
+    });
+  });
+});

--- a/functions/test/now-playing-handler.test.js
+++ b/functions/test/now-playing-handler.test.js
@@ -423,6 +423,96 @@ describe('Now Playing delivery through sendPushNotification', () => {
     /// belongs to the notification quota alone; this ceiling is a machine-readable refusal.
   });
 
+  describe('accounting that fails after APNs has answered', () => {
+    /// Apple's answer is the result of the request. Bookkeeping happens after it and must never
+    /// replace it, because the answer that matters most is the one that retires a dead token.
+    ///
+    /// Lets the two pre-send charges through and fails everything after them, so these exercise
+    /// the accounting that runs once APNs has already answered rather than failing earlier for
+    /// the wrong reason.
+    const breakAccountingAfterSend = () => {
+      const working = mockFirestore.runTransaction.getMockImplementation();
+      mockFirestore.runTransaction
+        .mockImplementationOnce(working)
+        .mockImplementationOnce(working)
+        .mockRejectedValue(new Error('firestore is unavailable'));
+    };
+
+    test('a delivery is still reported when recordSuccess throws', async () => {
+      setNowPlayingProvider(fakeProvider({ status: 200, apnsId: 'APNS-42', reason: null }));
+      req = createMockRequest({ body: nowPlayingBody() });
+      breakAccountingAfterSend();
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ messageId: 'APNS-42' }));
+    });
+
+    /// The first row is the one that matters most: a dead token is the only answer that retires a
+    /// registration, and losing it behind a database exception means Home Assistant keeps pushing
+    /// at a token that will never work again. The rest are here because every refusal has to keep
+    /// its own classification, not just that one.
+    test.each([
+      [410, 'Unregistered', 410, 'InvalidToken'],
+      [400, 'DeviceTokenNotForTopic', 400, 'TopicMismatch'],
+      [403, 'InvalidProviderToken', 502, 'ProviderAuth'],
+      [429, 'TooManyRequests', 429, 'ApnsRateLimited'],
+      [503, 'ServiceUnavailable', 502, 'ApnsUnavailable'],
+    ])(
+      'APNs %i %s still answers HTTP %i %s when accounting throws',
+      async (apnsStatus, reason, httpStatus, errorType) => {
+        setNowPlayingProvider(fakeProvider({ status: apnsStatus, apnsId: 'APNS-1', reason }));
+        req = createMockRequest({ body: nowPlayingBody() });
+        breakAccountingAfterSend();
+        await handlers.handleRequest(req, res, legacy.createPayload);
+
+        expect(res.status).toHaveBeenCalledWith(httpStatus);
+        expect(res.send).toHaveBeenCalledWith(
+          expect.objectContaining({ errorType, errorCode: reason }),
+        );
+      },
+    );
+
+    /// Reaching APNs at all is what separates this from the pre-send case.
+    test('a send that never reached Apple still reports that, not the accounting failure', async () => {
+      setNowPlayingProvider(fakeProvider(new Error('ECONNRESET')));
+      req = createMockRequest({ body: nowPlayingBody() });
+      breakAccountingAfterSend();
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(res.status).toHaveBeenCalledWith(502);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ errorType: 'ApnsUnavailable' }),
+      );
+    });
+
+    /// The failure is not swallowed. It goes to its own error stream so it is not read as a
+    /// delivery problem.
+    test('the accounting failure is reported under its own step', async () => {
+      setNowPlayingProvider(fakeProvider({ status: 200, apnsId: 'APNS-1', reason: null }));
+      req = createMockRequest({ body: nowPlayingBody() });
+      breakAccountingAfterSend();
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(mockLogging.log).toHaveBeenCalledWith('errors-recordNowPlayingRateLimit');
+    });
+
+    /// Before the send is a different matter: nothing has happened yet, so refusing is safe and
+    /// charging nothing is the honest answer.
+    test('an accounting failure before the send still fails the request', async () => {
+      const provider = fakeProvider();
+      setNowPlayingProvider(provider);
+      req = createMockRequest({ body: nowPlayingBody() });
+      mockFirestore.collection.mockImplementation(() => {
+        throw new Error('firestore is unavailable');
+      });
+      await handlers.handleRequest(req, res, legacy.createPayload);
+
+      expect(provider.sent).toHaveLength(0);
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
   describe('logging', () => {
     test('the destination token is redacted from error reports', () => {
       const body = nowPlayingBody();

--- a/functions/test/now-playing-integration.test.js
+++ b/functions/test/now-playing-integration.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const http2 = require('node:http2');
+const crypto = require('node:crypto');
+
+const { ApnsProvider } = require('../apns-provider');
+const { prepareNowPlaying, classifyApnsResponse } = require('../now-playing');
+
+// A throwaway key, generated per run. Never a real credential.
+const { privateKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+const KEY_PEM = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+const TOKEN = 'de1ec7ab1ede1ec7ab1ede1ec7ab1ede';
+
+/**
+ * A local stand-in for Apple's provider API, over real HTTP/2.
+ *
+ * The unit tests drive a fake connector, which cannot catch a mistake in how the request is
+ * actually framed. This exercises the shipped `ApnsProvider` over a genuine HTTP/2 connection,
+ * everything but Apple's TLS and their servers, and records exactly what a provider would see.
+ */
+function startFakeApns() {
+  const received = [];
+  let answer = { status: 200, body: null };
+
+  const server = http2.createServer();
+  server.on('stream', (stream, headers) => {
+    const chunks = [];
+    stream.on('data', (chunk) => chunks.push(chunk));
+    stream.on('end', () => {
+      received.push({ headers, body: Buffer.concat(chunks).toString('utf8') });
+      const responseHeaders = { ':status': answer.status, 'apns-id': 'LOCAL-APNS-ID' };
+      if (answer.body) {
+        stream.respond(responseHeaders);
+        stream.end(JSON.stringify(answer.body));
+      } else {
+        stream.respond(responseHeaders);
+        stream.end();
+      }
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = /** @type {any} */ (server.address());
+      resolve({
+        received,
+        origin: `http://127.0.0.1:${port}`,
+        reply(status, body = null) {
+          answer = { status, body };
+        },
+        close: () =>
+          new Promise((done) => {
+            server.close(() => done(undefined));
+          }),
+      });
+    });
+  });
+}
+
+describe('Now Playing over a real HTTP/2 connection', () => {
+  let apns;
+  let provider;
+
+  const body = (overrides = {}) => ({
+    push_token: 'test:token123',
+    now_playing_token: TOKEN,
+    registration_info: { app_id: 'io.robbie.HomeAssistant' },
+    now_playing: {
+      event: 'update',
+      timestamp: 1788749001,
+      attributes: { id: 'remote-media-123', schemaVersion: 1 },
+      ...overrides,
+    },
+  });
+
+  const deliver = (requestBody) => {
+    const prepared = prepareNowPlaying(requestBody);
+    expect(prepared.ok).toBe(true);
+    return provider.send(prepared.request);
+  };
+
+  beforeEach(async () => {
+    apns = await startFakeApns();
+    provider = new ApnsProvider({
+      key: KEY_PEM,
+      keyId: 'TESTKEYID1',
+      teamId: 'TESTTEAM01',
+      connect: () => http2.connect(apns.origin),
+    });
+  });
+
+  afterEach(async () => {
+    provider.close();
+    await apns.close();
+  });
+
+  /// One connection, two sends: the pseudo-headers, the Authorization header, the wire body and
+  /// the caller's ordering clock, all as node:http2 actually frames them.
+  test('two updates arrive as Apple documents them, over one connection', async () => {
+    apns.reply(200);
+    const first = await deliver(body({ attributes: { id: 'remote-media-123', title: 'First' } }));
+    await deliver(
+      body({ timestamp: 1788749002, attributes: { id: 'remote-media-123', title: 'Second' } }),
+    );
+
+    expect(first).toEqual({ status: 200, apnsId: 'LOCAL-APNS-ID', reason: null });
+    expect(classifyApnsResponse(first)).toEqual({ ok: true, httpStatus: 201 });
+
+    expect(apns.received).toHaveLength(2);
+    const [request] = apns.received;
+    expect(request.headers[':method']).toBe('POST');
+    expect(request.headers[':path']).toBe(`/3/device/${TOKEN}`);
+    expect(request.headers['apns-push-type']).toBe('nowplaying');
+    expect(request.headers['apns-topic']).toBe('io.robbie.HomeAssistant.push-type.nowplaying');
+    expect(request.headers.authorization).toMatch(/^bearer /);
+    expect(JSON.parse(request.body)).toEqual({
+      aps: {
+        event: 'update',
+        timestamp: 1788749001,
+        attributes: { id: 'remote-media-123', title: 'First' },
+      },
+    });
+
+    expect(apns.received.map((r) => JSON.parse(r.body).aps.timestamp)).toEqual([
+      1788749001, 1788749002,
+    ]);
+    // One session, reused: the same provider JWT went out both times.
+    expect(apns.received[0].headers.authorization).toBe(apns.received[1].headers.authorization);
+  });
+
+  test('a real refusal body is read back off the wire and classified', async () => {
+    apns.reply(410, { reason: 'Unregistered' });
+    const result = await deliver(body());
+    expect(result).toMatchObject({ status: 410, reason: 'Unregistered' });
+    expect(classifyApnsResponse(result)).toMatchObject({ ok: false, errorType: 'InvalidToken' });
+  });
+
+  test('a connection that goes away mid-flight is reported, and the next send reconnects', async () => {
+    apns.reply(200);
+    await deliver(body());
+    // Apple closing the connection is routine; the provider must not wedge.
+    provider.session.destroy();
+    apns.reply(200);
+    await expect(deliver(body({ timestamp: 1788749009 }))).resolves.toMatchObject({ status: 200 });
+    expect(apns.received).toHaveLength(2);
+  });
+});

--- a/functions/test/now-playing.test.js
+++ b/functions/test/now-playing.test.js
@@ -1,0 +1,373 @@
+'use strict';
+
+const {
+  isNowPlayingRequest,
+  prepareNowPlaying,
+  classifyApnsResponse,
+  destinationIdentity,
+  tokenFingerprint,
+  MAX_PAYLOAD_BYTES,
+} = require('../now-playing');
+
+const TOKEN = 'de1ec7ab1ede1ec7ab1ede1ec7ab1ede';
+const OFFICIAL_APP_ID = 'io.robbie.HomeAssistant';
+const ALLOWED_APP_IDS_VARIABLE = 'NOW_PLAYING_APNS_ALLOWED_APP_IDS';
+
+const baseBody = (overrides = {}) => {
+  const { now_playing: nowPlaying, ...rest } = overrides;
+  return {
+    push_token: 'test:token123',
+    now_playing_token: TOKEN,
+    registration_info: {
+      app_id: OFFICIAL_APP_ID,
+      app_version: '2026.9.1',
+      webhook_id: 'webhook-1',
+      os_version: '27.0',
+    },
+    ...rest,
+    now_playing: {
+      event: 'update',
+      timestamp: 1788749001,
+      attributes: { id: 'remote-media-123', schemaVersion: 1 },
+      ...(nowPlaying || {}),
+    },
+  };
+};
+
+const payloadOf = (result) => JSON.parse(result.request.body.toString('utf8'));
+
+const topicFor = (appId) => prepareNowPlaying(baseBody({ registration_info: { app_id: appId } }));
+
+// Mirrors the module's syntax rule, so a test can show an identifier is well formed and still
+// refused. If the two ever disagree these assertions fail loudly rather than silently pass.
+const APP_ID_SHAPE = /^[A-Za-z0-9][A-Za-z0-9-]*(\.[A-Za-z0-9][A-Za-z0-9-]*)+$/;
+
+describe('request detection', () => {
+  test('only a now_playing_token selects this path', () => {
+    expect(isNowPlayingRequest({ now_playing_token: TOKEN })).toBe(true);
+    expect(isNowPlayingRequest({ push_token: 'test:token123' })).toBe(false);
+    expect(isNowPlayingRequest({ live_activity_token: 'abc' })).toBe(false);
+    expect(isNowPlayingRequest({})).toBe(false);
+    expect(isNowPlayingRequest(null)).toBe(false);
+  });
+});
+
+describe('payload', () => {
+  test('an update is exactly the aps envelope Apple documents, and nothing else', () => {
+    const result = prepareNowPlaying(baseBody());
+    expect(result.ok).toBe(true);
+    expect(result.request.pushType).toBe('nowplaying');
+    expect(payloadOf(result)).toEqual({
+      aps: {
+        event: 'update',
+        timestamp: 1788749001,
+        attributes: { id: 'remote-media-123', schemaVersion: 1 },
+      },
+    });
+    // No alert, sound, badge or content-available: this is not a notification.
+    expect(Object.keys(payloadOf(result))).toEqual(['aps']);
+    expect(Object.keys(payloadOf(result).aps).sort()).toEqual(['attributes', 'event', 'timestamp']);
+  });
+
+  test('an end is the same envelope with the session identity', () => {
+    const result = prepareNowPlaying(
+      baseBody({
+        now_playing: {
+          event: 'end',
+          timestamp: 1788749002,
+          attributes: { id: 'remote-media-123' },
+        },
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.event).toBe('end');
+    expect(payloadOf(result)).toEqual({
+      aps: { event: 'end', timestamp: 1788749002, attributes: { id: 'remote-media-123' } },
+    });
+  });
+
+  /// A versioned cross-repo protocol: an older relay must pass a newer schema through, and the
+  /// ordering clock is the caller's, and APNs sequences a session's pushes by it.
+  test('forwards unknown attributes and the caller timestamp untouched', () => {
+    const attributes = {
+      id: 'remote-media-123',
+      schemaVersion: 7,
+      somethingAddedLater: { nested: [1, 2, 3] },
+      positionUpdatedAtUnix: 1788749875.123,
+    };
+    const payload = payloadOf(
+      prepareNowPlaying(baseBody({ now_playing: { timestamp: 1500000000, attributes } })),
+    );
+    expect(payload.aps.attributes).toEqual(attributes);
+    expect(payload.aps.timestamp).toBe(1500000000);
+  });
+});
+
+describe('validation', () => {
+  test.each([
+    [
+      'both specialised tokens is ambiguous',
+      { live_activity_token: 'la-token' },
+      400,
+      'AmbiguousRequest',
+    ],
+    ['a token that is not hex', { now_playing_token: 'zzzz' }, 400, 'InvalidNowPlayingToken'],
+    ['a token of odd length', { now_playing_token: 'abc' }, 400, 'InvalidNowPlayingToken'],
+    ['an empty token', { now_playing_token: '' }, 400, 'InvalidNowPlayingToken'],
+    ['a token of the wrong type', { now_playing_token: 1234 }, 400, 'InvalidNowPlayingToken'],
+    [
+      'a now_playing that is not an object',
+      { now_playing: 'nope' },
+      400,
+      'InvalidNowPlayingRequest',
+    ],
+  ])('rejects %s', (_label, overrides, status, errorType) => {
+    const result = prepareNowPlaying({ ...baseBody(), ...overrides });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(status);
+    expect(result.error).toMatchObject({ errorType });
+  });
+
+  test('rejects a missing now_playing object', () => {
+    const body = baseBody();
+    delete body.now_playing;
+    expect(prepareNowPlaying(body).error).toMatchObject({ errorType: 'InvalidNowPlayingRequest' });
+  });
+
+  /// `start` is push-to-start, which this product has no use for: a session exists because the
+  /// user chose Follow.
+  test.each([['start'], ['begin'], [''], [undefined]])('rejects the event %p', (event) => {
+    expect(prepareNowPlaying(baseBody({ now_playing: { event } })).error).toMatchObject({
+      errorType: 'UnsupportedNowPlayingEvent',
+    });
+  });
+
+  test.each([
+    ['a float', 1788749001.5],
+    ['a string', '1788749001'],
+    ['zero', 0],
+    ['negative', -1],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['missing', undefined],
+  ])('rejects a timestamp that is %s', (_label, timestamp) => {
+    expect(prepareNowPlaying(baseBody({ now_playing: { timestamp } })).error).toMatchObject({
+      errorType: 'InvalidNowPlayingTimestamp',
+    });
+  });
+
+  test.each([
+    ['an array', []],
+    ['a string', 'nope'],
+    ['missing', undefined],
+  ])('rejects attributes that are %s', (_label, attributes) => {
+    expect(prepareNowPlaying(baseBody({ now_playing: { attributes } })).error).toMatchObject({
+      errorType: 'InvalidNowPlayingAttributes',
+    });
+  });
+
+  /// iOS routes the push by attributes.id. Without it APNs answers 200 and the device silently
+  /// discards the push, so refusing here is the only way the caller learns anything.
+  test.each([
+    ['missing', {}],
+    ['empty', { id: '' }],
+    ['the wrong type', { id: 7 }],
+  ])('rejects an attributes id that is %s', (_label, attributes) => {
+    expect(prepareNowPlaying(baseBody({ now_playing: { attributes } })).error).toMatchObject({
+      errorType: 'MissingNowPlayingSessionId',
+    });
+  });
+});
+
+describe('topic authorization', () => {
+  const originalAllowed = process.env[ALLOWED_APP_IDS_VARIABLE];
+
+  afterEach(() => {
+    if (originalAllowed === undefined) delete process.env[ALLOWED_APP_IDS_VARIABLE];
+    else process.env[ALLOWED_APP_IDS_VARIABLE] = originalAllowed;
+  });
+
+  /// The App Store identifier, which TestFlight builds and Mac Catalyst share.
+  test('the official app is served out of the box', () => {
+    delete process.env[ALLOWED_APP_IDS_VARIABLE];
+    expect(topicFor(OFFICIAL_APP_ID).request.topic).toBe(
+      'io.robbie.HomeAssistant.push-type.nowplaying',
+    );
+  });
+
+  test('a deployment can name additional exact identifiers', () => {
+    process.env[ALLOWED_APP_IDS_VARIABLE] = 'io.robbie.HomeAssistant.dev, com.example.fork';
+    expect(topicFor('io.robbie.HomeAssistant.dev').request.topic).toBe(
+      'io.robbie.HomeAssistant.dev.push-type.nowplaying',
+    );
+    expect(topicFor('com.example.fork').ok).toBe(true);
+    // Configuring one does not imply anything near it.
+    expect(topicFor('com.example.fork.evil').ok).toBe(false);
+    expect(topicFor('com.example').ok).toBe(false);
+  });
+
+  /// A syntactically valid bundle identifier is not an authorized one: the topic is selected
+  /// under a team-scoped signing key, so anything the team can sign would otherwise be reachable.
+  test.each([
+    ['a different vendor', 'evil.example.app'],
+    ['a suffix of the official id', 'io.robbie.HomeAssistant.evil'],
+    ['a prefix of the official id', 'io.robbie'],
+    ['a lookalike', 'io.robbie.HomeAssistantt'],
+    ['a case variant', 'io.robbie.homeassistant'],
+    ['the debug id, which is not built in', 'io.robbie.HomeAssistant.dev'],
+  ])('refuses %s even though it is well formed', (_label, appId) => {
+    delete process.env[ALLOWED_APP_IDS_VARIABLE];
+    expect(APP_ID_SHAPE.test(appId)).toBe(true);
+    const result = topicFor(appId);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(403);
+    expect(result.error).toMatchObject({ errorType: 'UnsupportedApp' });
+    // The refusal does not disclose which apps are configured.
+    expect(JSON.stringify(result.error)).not.toContain('io.robbie');
+  });
+
+  test.each([
+    ['missing', undefined],
+    ['empty', ''],
+    ['no dot', 'HomeAssistant'],
+    ['a leading dot', '.io.robbie'],
+    ['a trailing dot', 'io.robbie.'],
+    ['a path', 'io.robbie/../other'],
+    ['a space', 'io.robbie Home'],
+    ['header injection', 'io.robbie\r\nx-evil: 1'],
+    ['the wrong type', 42],
+    ['too long', `io.robbie.${'a'.repeat(200)}`],
+  ])('refuses an app id that is %s', (_label, appId) => {
+    expect(topicFor(appId).error).toMatchObject({ errorType: 'UnsupportedApp' });
+  });
+
+  test('refuses a missing or non-object registration_info', () => {
+    const body = baseBody();
+    delete body.registration_info;
+    expect(prepareNowPlaying(body).error).toMatchObject({ errorType: 'UnsupportedApp' });
+    expect(prepareNowPlaying(baseBody({ registration_info: OFFICIAL_APP_ID })).ok).toBe(false);
+  });
+
+  /// The configuration mistake that would matter most: a wildcard must never widen anything. It
+  /// authorizes an app literally called `*`, which is not a bundle identifier and cannot exist.
+  test.each([['*'], ['**'], ['io.robbie.*'], ['io.robbie.HomeAssistant*'], ['.*']])(
+    'a configured %p is literal and authorizes nothing real',
+    (pattern) => {
+      process.env[ALLOWED_APP_IDS_VARIABLE] = pattern;
+      expect(topicFor('evil.example.app').ok).toBe(false);
+      expect(topicFor('io.robbie.HomeAssistant.dev').ok).toBe(false);
+      expect(topicFor(pattern).ok).toBe(false);
+      // And the app that was already served is unaffected.
+      expect(topicFor(OFFICIAL_APP_ID).ok).toBe(true);
+    },
+  );
+
+  /// The caller must never be able to choose where a push goes.
+  test('a caller-supplied topic cannot override the derived one', () => {
+    const result = prepareNowPlaying(
+      baseBody({
+        apns_topic: 'com.attacker.app.push-type.nowplaying',
+        topic: 'com.attacker.app',
+        now_playing_topic: 'com.attacker.app',
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.request.topic).toBe('io.robbie.HomeAssistant.push-type.nowplaying');
+  });
+});
+
+describe('payload size', () => {
+  const withPadding = (bytes) =>
+    baseBody({
+      now_playing: { attributes: { id: 'remote-media-123', pad: 'x'.repeat(bytes) } },
+    });
+
+  /// Apple's documented 4 KB maximum, checked before a connection is opened.
+  test('the boundary is exactly Apple maximum', () => {
+    // The envelope is fixed and the padding is one JSON byte per character, so this is exact.
+    const envelopeBytes = prepareNowPlaying(withPadding(0)).request.body.length;
+    const fits = prepareNowPlaying(withPadding(MAX_PAYLOAD_BYTES - envelopeBytes));
+    expect(fits.ok).toBe(true);
+    expect(fits.request.body.length).toBe(MAX_PAYLOAD_BYTES);
+
+    const tooBig = prepareNowPlaying(withPadding(MAX_PAYLOAD_BYTES - envelopeBytes + 1));
+    expect(tooBig.ok).toBe(false);
+    expect(tooBig.status).toBe(413);
+    expect(tooBig.error).toMatchObject({ errorType: 'PayloadTooLarge' });
+  });
+
+  test('the refusal does not quote the oversized payload', () => {
+    const secret = 'do-not-log-me-'.repeat(400);
+    const result = prepareNowPlaying(
+      baseBody({ now_playing: { attributes: { id: 'remote-media-123', pad: secret } } }),
+    );
+    expect(result.ok).toBe(false);
+    expect(JSON.stringify(result.error)).not.toContain('do-not-log-me');
+  });
+});
+
+describe('APNs response classification', () => {
+  test('200 is success', () => {
+    expect(classifyApnsResponse({ status: 200, reason: null })).toEqual({
+      ok: true,
+      httpStatus: 201,
+    });
+  });
+
+  /// Apple's answer to the outcome Home Assistant acts on. `InvalidToken` is the only one that
+  /// unregisters a user's session, so nothing but a genuinely dead token may map to it,
+  /// including a refusal we do not recognise.
+  test.each([
+    [410, 'Unregistered', 'InvalidToken', 410],
+    [400, 'BadDeviceToken', 'InvalidToken', 410],
+    [410, null, 'InvalidToken', 410],
+    [400, 'DeviceTokenNotForTopic', 'TopicMismatch', 400],
+    [400, 'TopicDisallowed', 'TopicMismatch', 400],
+    [400, 'BadTopic', 'TopicMismatch', 400],
+    [403, 'InvalidProviderToken', 'ProviderAuth', 502],
+    [403, 'ExpiredProviderToken', 'ProviderAuth', 502],
+    [403, null, 'ProviderAuth', 502],
+    [413, 'PayloadTooLarge', 'PayloadTooLarge', 413],
+    [429, 'TooManyRequests', 'ApnsRateLimited', 429],
+    [500, 'InternalServerError', 'ApnsUnavailable', 502],
+    [503, 'ServiceUnavailable', 'ApnsUnavailable', 502],
+    [503, null, 'ApnsUnavailable', 502],
+    [400, 'SomethingNewFromApple', 'ApnsError', 502],
+    [418, null, 'ApnsError', 502],
+  ])('APNs %i %s is %s, answered as HTTP %i', (status, reason, errorType, httpStatus) => {
+    expect(classifyApnsResponse({ status, reason })).toEqual({ ok: false, errorType, httpStatus });
+  });
+});
+
+describe('destination identity', () => {
+  /// The Companion token is only checked for shape before this path is taken, so it cannot be the
+  /// only thing a quota is keyed on. This names the device the push actually reaches.
+  test('is a full digest, so two devices cannot share a bucket by chance', () => {
+    const identity = destinationIdentity(TOKEN);
+    expect(identity).toHaveLength(64);
+    expect(identity).toMatch(/^[0-9a-f]+$/);
+    expect(identity).not.toContain(TOKEN);
+    expect(destinationIdentity(`${TOKEN}ff`)).not.toBe(identity);
+  });
+
+  /// The token is validated as case-insensitive hex, so the same device written two ways is one
+  /// device and must not be handed two quotas.
+  test('does not care how the token is cased', () => {
+    expect(destinationIdentity(TOKEN.toUpperCase())).toBe(destinationIdentity(TOKEN.toLowerCase()));
+  });
+
+  /// Long enough that a collision is not a way to spend someone else's quota, where the truncated
+  /// logging fingerprint would not be.
+  test('is longer than the label used for logs', () => {
+    expect(destinationIdentity(TOKEN).length).toBeGreaterThan(tokenFingerprint(TOKEN).length);
+  });
+});
+
+describe('token fingerprint', () => {
+  test('is stable, short, distinguishing and not the token', () => {
+    expect(tokenFingerprint(TOKEN)).toBe(tokenFingerprint(TOKEN));
+    expect(tokenFingerprint(TOKEN)).toHaveLength(16);
+    expect(TOKEN).not.toContain(tokenFingerprint(TOKEN));
+    expect(tokenFingerprint(TOKEN)).not.toBe(tokenFingerprint(`${TOKEN}ff`));
+  });
+});

--- a/functions/test/rate-limiter/key-namespace.test.js
+++ b/functions/test/rate-limiter/key-namespace.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const { getToday, NOW_PLAYING_KEY_PREFIX } = require('../../rate-limiter/util');
+
+const mockFirestore = { collection: jest.fn(), runTransaction: jest.fn() };
+
+jest.mock('firebase-admin/app', () => ({ initializeApp: jest.fn() }));
+jest.mock('firebase-admin/firestore', () => ({
+  getFirestore: jest.fn(() => mockFirestore),
+  Timestamp: { fromDate: jest.fn(() => 'mock-timestamp') },
+}));
+
+const FirestoreRateLimiter = require('../../rate-limiter/firestore-rate-limiter');
+const ValkeyRateLimiter = require('../../rate-limiter/valkey-rate-limiter');
+
+const TOKEN = 'test:token123';
+
+/** Records the collection path and document id a Firestore limiter addresses. */
+const firestoreDoc = (limiter) => {
+  const captured = {};
+  const dayDoc = jest.fn((day) => {
+    captured.day = day;
+    return {
+      collection: jest.fn(() => ({
+        doc: jest.fn((id) => {
+          captured.id = id;
+          return {};
+        }),
+      })),
+    };
+  });
+  mockFirestore.collection.mockReturnValue({ doc: dayDoc });
+  limiter._getDocRef(TOKEN);
+  captured.collection = mockFirestore.collection.mock.calls[0][0];
+  return captured;
+};
+
+/// The Now Playing quota is a second counter for the same token, in the same backend and under
+/// the same day partition. The notification bucket's storage layout must be exactly what it
+/// always was, so an unprefixed limiter has to produce byte-identical keys.
+describe('rate-limit key namespacing', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('Firestore: the Now Playing bucket is a separate document, same day partition', () => {
+    const notifications = firestoreDoc(new FirestoreRateLimiter(500, false));
+    expect(notifications).toEqual({ collection: 'rateLimits', day: getToday(), id: TOKEN });
+
+    const nowPlaying = firestoreDoc(new FirestoreRateLimiter(5000, false, NOW_PLAYING_KEY_PREFIX));
+    expect(nowPlaying).toEqual({
+      collection: 'rateLimits',
+      day: getToday(),
+      id: `${NOW_PLAYING_KEY_PREFIX}${TOKEN}`,
+    });
+  });
+
+  test('Valkey: the Now Playing bucket is a separate key for the same token', () => {
+    const notifications = new ValkeyRateLimiter(500, false, 'localhost', 6379);
+    expect(notifications._getValkeyKey(TOKEN)).toBe(`rate_limit:${TOKEN}:${getToday()}`);
+
+    const nowPlaying = new ValkeyRateLimiter(
+      5000,
+      false,
+      'localhost',
+      6379,
+      NOW_PLAYING_KEY_PREFIX,
+    );
+    expect(nowPlaying._getValkeyKey(TOKEN)).toBe(
+      `rate_limit:${NOW_PLAYING_KEY_PREFIX}${TOKEN}:${getToday()}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds direct APNs delivery for iOS 27 Remote Now Playing sessions. Remote Now Playing (new in iOS 27) uses its own APNs session token. Firebase admin supports Live Activity tokens, but it does not expose a way to address a Remote Now Playing session, so these updates need to go to apns directly.

This will allow the companion app to use Remote Now Playing for media_player entities.

## How it works

Requests with a `now_playing_token` are sent directly to APNs over HTTP/2 using: `apns-push-type: nowplaying`

and the topic: `<app id>.push-type.nowplaying` While everything else stays going through the existing Firebase path

The APNs topic comes from `registration_info.app_id` rather than being supplied by the request. The production Companion app ID is allowed by default, and any other app IDs would need to be configured with `NOW_PLAYING_APNS_ALLOWED_APP_IDS`.

### Rate limiting

Now Playing updates are metered separately from notifications, in their own namespace in the same store. There are two counters there and a send needs both to allow it. One is keyed on the Companion push token. That isn't enough on its own, because this path doesnt hand that token to Firebase and so only ever checks its shape, which means a caller could make up a new one per request and get a fresh bucket each time while pushing at just one device. The second is keyed on a SHA-256 of the destination token, so the device the push reaches is metered whichever registration claims to be sending.

### Responses

All of the payloads are validated and checked against APNs' 4096-byte limit before sending. Also the destination tokens are fingerprinted. If Remote Now Playing APNs credentials are not configured, these requests are just rejected

### Configuration

- `NOW_PLAYING_APNS_KEY`
- `NOW_PLAYING_APNS_KEY_ID`
- `NOW_PLAYING_APNS_TEAM_ID`
- `NOW_PLAYING_APNS_PRODUCTION`
- `NOW_PLAYING_APNS_ALLOWED_APP_IDS`
- `MAX_NOW_PLAYING_UPDATES_PER_DAY`

## Testing

New tests for
- request and payload validation
- app ID authorization
- APNs response handling
- JWT generation and caching
- HTTP/2 connection reuse and reconnect
- separate rate-limit namespaces
- logging/redaction
- local HTTP/2 APNs integration

I also tested the full path locally with Home Assistant Core and a physical iPhone. Remote Now Playing metadata updates reached the Lock Screen with the Companion app force-closed, and playback controls were sent back to Home Assistant (as expected)

`npm run lint` and Prettier pass.

`npm test` passes 271 tests with 2 timezone failures already on main in valkey-rate-limiter.test.js

`npm run typecheck` same existing errors as `main`.